### PR TITLE
Formatting Fix For Bicep Policy Set Def Output

### DIFF
--- a/.github/scripts/Invoke-PolicyToBicep.ps1
+++ b/.github/scripts/Invoke-PolicyToBicep.ps1
@@ -2,7 +2,7 @@
 SUMMARY: This PowerShell script helps with the authoring of the policy definiton module by outputting information required for the variables within the module.
 DESCRIPTION: This PowerShell script outputs the Name & Path to a Bicep strucutred .txt file named '_policyDefinitionsBicepInput.txt' and '_policySetDefinitionsBicepInput.txt' respectively. It also creates a parameters file for each of the policy set definitions. It also outputs the number of policies definition and set definition files to the console for easier reviewing as part of the PR process.
 AUTHOR/S: jtracey93
-VERSION: 1.4.0
+VERSION: 1.4.1
 #>
 
 # Policy Definitions


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR makes a small fix to the `_policySetDefinitionsBicepInput.txt` output file where the indentation at the end of each object was incorrect

## This PR fixes/adds/changes/removes

1. Formatting fix to output of `_policySetDefinitionsBicepInput.txt`
2. Updated to V1.4.1 for `Invoke-PolicyToBicep.ps1`

### Breaking Changes

None

## Testing Evidence

Tested locally and outputs as expected:

![image](https://user-images.githubusercontent.com/41163455/132822286-0aeb346e-c368-4955-99ec-4bdaf12adeff.png)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [ADO items] - [#70838](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_workitems/edit/70838)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
