### PR TITLE
Bug82312 Investigate why Bicep Build Test GitHub Action does not exit on error

### DIFF
--- a/.github/workflows/bicep-build-to-validate.yml
+++ b/.github/workflows/bicep-build-to-validate.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Bicep Build to Test for PR
         shell: pwsh
         run: |
-          Get-ChildItem -Recurse -Filter '*.bicep' -Exclude '*/docs/scripts/callModuleFromACR.example.bicep' | ForEach-Object {
+          Get-ChildItem -Recurse -Filter '*.bicep' -Exclude 'callModuleFromACR.example.bicep' | ForEach-Object {
               Write-Information "==> Attempting Bicep Build For File: $_" -InformationAction Continue
               $output = bicep build $_.FullName 2>&1
               if ($LastExitCode -ne 0)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixes problem described in [Bug 82312](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_workitems/edit/82312)

## This PR fixes/adds/changes/removes

1. Updates .github/workflows/bicep-build-to-validate.yml step Bicep Build to Test for PR to properly exclude callModuleFromACR.example.bicep
2. Updates .github/workflows/bicep-build-to-validate.yml step Bicep Build to Test for PR to evaluate last exit code from bicep.exe and exit if not 0

### Breaking Changes

No breaking changes

## Testing Evidence

1. Result with callModuleFromACR.example.bicep not properly excluded, i.e. the workflow should fail due to faulty references in file. 
![failingworkflow](https://user-images.githubusercontent.com/22591930/149323748-002e2380-4b48-4450-8e14-a909c3d27d23.png)
2. Result with callModuleFromACR.example.bicep properly excluded, i.e. the workflow should succeed since remaining files are valid.
![succesfulworkflow](https://user-images.githubusercontent.com/22591930/149323865-40c62444-5aba-4baa-a971-f4c78ac98cc7.png)



## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation. Not relevant as this is a minor change
