### PR TITLE
Push changes to handle pr close better

### DIFF
--- a/.github/workflows/cleanup-on-close-pr.yml
+++ b/.github/workflows/cleanup-on-close-pr.yml
@@ -46,7 +46,7 @@ jobs:
             $resourceGroups = @()
             $resourceGroups += Get-AzResourceGroup
             If ($resourceGroups.Count -gt 0) {
-                $resourceGroups | ForEach-Object {
+                $resourceGroups | ForEach-Object -Parallel {
                     Write-Information "Deleting resource group $($PSItem.ResourceGroupName)"
                     Remove-AzResourceGroup -Name $PSItem.ResourceGroupName -Force
                 }


### PR DESCRIPTION
# Overview/Summary

Resolves issue with subscription not getting canceled properly after PR close as described in [92230](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_workitems/edit/92230)

## This PR fixes/adds/changes/removes

1. Adds check to workflow as to whether subscription is even there.
2. If subscription is there delete all resource groups in subscription
3. Simplify code in actual subscription cancel step since checks has been done before.

### Breaking Changes

N/A

## Testing Evidence

Testing evidence to come when PR merges.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation. Not relevant.
