### PR TITLE
Fix cleanup process after build

### DIFF
--- a/.github/scripts/Wipe-ESLZAzTenant.ps1
+++ b/.github/scripts/Wipe-ESLZAzTenant.ps1
@@ -106,28 +106,6 @@ if ($null -ne $intermediateRootGroupChildSubscriptions) {
     Write-Information ""
 }
 
-# Removed because we are running through a pipeline  Can be enabled if running interactively.
-# Generate 8 character random string (combination of lowercase letters and integers)
-#$userConfirmationRandomID = -join ((48..57) + (97..122) | Get-Random -Count 8 | ForEach-Object { [char]$_ })
-#
-#Write-Output "To confirm the removal of the above Management Group hierarchy, moving the Subscriptions back to the Tenant Root Management Group, removing all Resoruces and Resource Groups from the Subscriptions and removing all Tenant, seleted/shown Management Groups, and selected/shown Management Groups deployments." -ForegroundColor Yellow
-#Write-Output ""
-#Write-Output "Please enter the following random string exactly: $userConfirmationRandomID" -ForegroundColor Yellow
-#Write-Output ""
-#
-#Write-Output "Please enter the random string shown above to confirm you wish to contine running this script."
-#$userConfirmationInputString = Read-Host -Prompt "(Leave blank or type anything that doesn't match the string above to cancel/terminate)"
-
-#if ($userConfirmationInputString -eq $userConfirmationRandomID) {
-#    Write-Output ""
-#    Write-Output "Confirmation string entered successfully, proceeding to remove hierarchy and resoruces as shown above..." -ForegroundColor Green
-#    Write-Output ""
-#}
-#else {
-#    Write-Output "Confirmation string not entered or incorrect, terminating script..." -ForegroundColor Red
-#    throw "Confirmation string not entered or incorrectly entered, terminating script..."
-#}
-
 Write-Information "Moving all subscriptions under tenant root management group: $tenantRootGroupID"
 
 # For each Subscription in Intermediate Root Management Group's hierarchy tree, move it to the Tenant Root Management Group
@@ -141,9 +119,6 @@ $intermediateRootGroupChildSubscriptions | ForEach-Object -Parallel {
 
 # For each Subscription in the Intermediate Root Management Group's hierarchy tree, remove all Resources, Resource Groups and Deployments
 Write-Information "Removing all Azure Resources, Resource Groups and Deployments from Subscriptions in scope"
-
-
-# ForEach ($subscription in $intermediateRootGroupChildSubscriptions) {
 $subscription = Get-AzSubscription -SubscriptionName $subscriptionName -ErrorAction SilentlyContinue
 If($subscription){
 Write-Information "Set context to SubscriptionId: '$($subscription.Id)'"

--- a/.github/workflows/bicep-build-to-validate.yml
+++ b/.github/workflows/bicep-build-to-validate.yml
@@ -218,12 +218,3 @@ jobs:
             install-module -Name "Az.Resources" -MinimumVersion "4.3.0" -Force
             install-module -Name "Az.ResourceGraph" -MinimumVersion "0.7.7"-Force
             .github/scripts/Wipe-ESLZAzTenant.ps1 -tenantRootGroupID "${{ secrets.ALZ_AZURE_SECRET_TENANT_ID }}" -intermediateRootGroupID "${{ env.ManagementGroupPrefix }}" -subscriptionName "${{ env.SubscriptionName }}"
-
-      # - name: Az Remove Resource Group
-      #   if: always()
-      #   shell: bash
-      #   run: |
-      #     az account set --subscription ${{ needs.bicep_deploy.outputs.subscriptionID}}
-      #     if [ $(az group exists --name ${{ env.ResourceGroupName }} ) == true ]; then
-      #       az group delete --name ${{ env.ResourceGroupName }} --yes
-      #     fi


### PR DESCRIPTION
# Overview/Summary
Fixes the problem that Bicep build test cleanup does not delete all resource groups. Described here [92977](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_workitems/edit/92977)

## This PR fixes/adds/changes/removes

1. Change bicep-build-to-validate.yml to include subscriptionname as parameter when calling Wipe-ESLZAzTenant.ps1.
2. Removes step Az Remove Resource Group from bicep-build-to-validate.yml as that should now be handled by Wipe-ESLZAzTenant.ps1
3. Modify Wipe-ESLZAzTenant.ps1 to take subscription name as input and use that rather than management group subscriptions as basis for subscription(s) to work with.
4. Modify Wipe-ESLZAzTenant.ps1 to use write-information rather than write-output and removed -foregroundcolor switch since it doesn't work.

### Breaking Changes

N/A

## Testing Evidence

Tested this manually on subscription left over from PR 110. Further testing to be provided by PR itself.

Updated: Ran successfully (see here: https://github.com/Azure/ALZ-Bicep/runs/4992038983?check_suite_focus=true) and successfully removed resource groups from subscription. see below:

![image](https://user-images.githubusercontent.com/22591930/151668783-59d4e044-638d-4aed-80d9-b57403cdcdc5.png)



## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
