### PR TITLE
Remove staging from wiki home

### DIFF
--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -4,7 +4,7 @@
 
 ![Bicep Logo](media/bicep-logo.png)
 
-Welcome to the wiki of the Azure Landing Zones Bicep repo. This repo contains the Azure Landing Zone Bicep modules that help you create and implement the [Azure Landing Zone Conceptual Architecture](https://docs.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/#azure-landing-zone-conceptual-architecture) in a modular approach. 
+Welcome to the wiki of the Azure Landing Zones Bicep repo. This repo contains the Azure Landing Zone Bicep modules that help you create and implement the [Azure Landing Zone Conceptual Architecture](https://docs.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/#azure-landing-zone-conceptual-architecture) in a modular approach.
 
 Artefacts like policies etc. are pulled down from the [`Azure/Enterprise-Scale` repo](https://github.com/Azure/Enterprise-Scale) to ensure the choice of tooling to implement the architecture, produce the same outputs.
 


### PR DESCRIPTION
# Overview/Summary

Remove staging label from wiki home. #[92744](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_workitems/edit/92744)

## This PR fixes/adds/changes/removes

1. Removes any references to staging from the wiki home.md file. 

### Breaking Changes

N/A
## Testing Evidence

Documentation only. Linter should suffice

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
