### PR TITLE
Update for Policy Initiative management group targets

### DIFF
--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
@@ -468,7 +468,7 @@ module modPolicyAssignmentIdentDeployVMBackup '../../../policy/assignments/polic
 // Modules - Policy Assignments - Management Management Group 
 // Module - Policy Assignment - Deploy-Log-Analytics
 module modPolicyAssignmentMgmtDeployLogAnalytics '../../../policy/assignments/policyAssignmentManagementGroup.bicep' = {
-  scope: managementGroup(varManagementGroupIDs.platformIdentity)
+  scope: managementGroup(varManagementGroupIDs.platformManagement)
   name: varModuleDeploymentNames.modPolicyAssignmentMgmtDeployLogAnalytics
   params: {
     parPolicyAssignmentDefinitionID: varPolicyAssignmentDeployLogAnalytics.definitionID
@@ -737,7 +737,7 @@ module modPolicyAssignmentLZsDeploySQLThreat '../../../policy/assignments/policy
 // Modules - Policy Assignments - Corp Management Group
 // Module - Policy Assignment - Deny-Public-Endpoints
 module modPolicyAssignmentLZsDenyPublicEndpoints '../../../policy/assignments/policyAssignmentManagementGroup.bicep' = {
-  scope: managementGroup(varManagementGroupIDs.landingZones)
+  scope: managementGroup(varManagementGroupIDs.landingZonesCorp)
   name: varModuleDeploymentNames.modPolicyAssignmentLZsDenyPublicEndpoints
   params: {
     parPolicyAssignmentDefinitionID: varPolicyAssignmentDenyPublicEndpoints.definitionID


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Two small errors for 
Deploy-Log-Analytics --> Targets Connectivity management group --> Should target Management management group
Deny-Public-Endpoints --> Targets LandingZone management group --> Should target Corp management group

Reference https://github.com/Azure/Enterprise-Scale/blob/main/docs/ESLZ-Policies.md 

## This PR fixes/adds/changes/removes

1. Change management group target for Deploy-Log-Analytics 
2. Change management group target for Deny-Public-Endpoints 

### Breaking Changes

1. If already implemented, updates for log analytics targets needs to be updated for diagnostic and azure monitor policies.

## Testing Evidence



## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
