### PR TITLE
Fix 2 Policy Assignment Scopes

### DIFF
--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
@@ -3,7 +3,7 @@
 SUMMARY: This module deploys the default Azure Landing Zone Azure Policy Assignments to the Management Group Hierarchy and also assigns the relevant RBAC.
 DESCRIPTION: This module deploys the default Azure Landing Zone Azure Policy Assignments to the Management Group Hierarchy and also assigns the relevant RBAC for the system-assigned Managed Identities created for policies that require them (e.g DeployIfNotExist & Modify effect policies).
 AUTHOR/S: jtracey93
-VERSION: 1.0.0
+VERSION: 1.0.1
 
 */
 

--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
@@ -468,7 +468,7 @@ module modPolicyAssignmentIdentDeployVMBackup '../../../policy/assignments/polic
 // Modules - Policy Assignments - Management Management Group 
 // Module - Policy Assignment - Deploy-Log-Analytics
 module modPolicyAssignmentMgmtDeployLogAnalytics '../../../policy/assignments/policyAssignmentManagementGroup.bicep' = {
-  scope: managementGroup(varManagementGroupIDs.platformIdentity)
+  scope: managementGroup(varManagementGroupIDs.platformManagement)
   name: varModuleDeploymentNames.modPolicyAssignmentMgmtDeployLogAnalytics
   params: {
     parPolicyAssignmentDefinitionID: varPolicyAssignmentDeployLogAnalytics.definitionID
@@ -737,7 +737,7 @@ module modPolicyAssignmentLZsDeploySQLThreat '../../../policy/assignments/policy
 // Modules - Policy Assignments - Corp Management Group
 // Module - Policy Assignment - Deny-Public-Endpoints
 module modPolicyAssignmentLZsDenyPublicEndpoints '../../../policy/assignments/policyAssignmentManagementGroup.bicep' = {
-  scope: managementGroup(varManagementGroupIDs.landingZones)
+  scope: managementGroup(varManagementGroupIDs.landingZonesCorp)
   name: varModuleDeploymentNames.modPolicyAssignmentLZsDenyPublicEndpoints
   params: {
     parPolicyAssignmentDefinitionID: varPolicyAssignmentDenyPublicEndpoints.definitionID


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Same as #131 - creating here as duplicate and will close #131 due to pipelines not running on forks currently (being worked on)

**From #131**
Two small errors for
Deploy-Log-Analytics --> Targets Connectivity management group --> Should target Management management group
Deny-Public-Endpoints --> Targets Landing Zone management group --> Should target Corp management group

## This PR fixes/adds/changes/removes

1. Change management group target for Deploy-Log-Analytics
2. Change management group target for Deny-Public-Endpoints

### Breaking Changes

None

## Testing Evidence

Unit Tests will provide some evidence of basics as well as linting. Also see below deployment evidence below:

![image](https://user-images.githubusercontent.com/41163455/153077447-1a9d93fd-940e-447d-a7c3-53739f697e02.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls) - #131 (will close)
- [ ] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
