### PR TITLE
Update unit tests for bicep and close PR job

### DIFF
--- a/.github/workflows/bicep-build-to-validate.yml
+++ b/.github/workflows/bicep-build-to-validate.yml
@@ -1,4 +1,4 @@
-name: Bicep Build Test for PR
+name: Unit Tests - Bicep Files and Modules
 
 on:
   pull_request:
@@ -8,16 +8,9 @@ on:
       - "**.bicep"
   workflow_dispatch: {}
 
-env:
-  ResourceGroupName: "rsg-github-pr-${{ github.event.number }}"
-  ManagementGroupPrefix: "PR-${{ github.event.number }}"
-  TopLevelManagementGroupDisplayName: "PR ${{ github.event.number }} Azure Landing Zones"
-  SubscriptionName: "sub-unit-test-pr-${{ github.event.number }}"
-  Location: "eastus"
-
 jobs:
   bicep_unit_tests:
-    name: Test Bicep Files for PR
+    name: Bicep Build & Lint All Modules
     runs-on: ubuntu-latest
 
     steps:
@@ -26,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Bicep Build to Test for PR
+      - name: Bicep Build & Lint All Modules
         shell: pwsh
         run: |
           Get-ChildItem -Recurse -Filter '*.bicep' -Exclude 'callModuleFromACR.example.bicep','orch-hubSpoke.bicep' | ForEach-Object {
@@ -41,170 +34,3 @@ jobs:
                 echo $output
               }   
           }
-
-  bicep_deploy:
-    name: Deploy Bicep Files for PR
-    runs-on: ubuntu-latest
-
-    environment: BicepUnitTests
-
-    outputs:
-      isDeployed: $(${{ env.gitLoggingOUTPUT != ''  }} || ${{ env.gitHubOUTPUT != ''  }} || ${{ env.gitSpokeOUTPUT != ''  }} || ${{ steps.git_management_diff.outputs.diff != '' != ''  }})
-      subscriptionID: ${{ env.SUBIDOUTPUT }}
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.ALZ_AZURE_SECRET_UNIT_TESTS }}
-          enable-AzPSSession: true
-
-      - name: Check for managementGroup Changes
-        id: git_management_diff
-        shell: bash
-        run: |
-          git diff --name-only HEAD^ HEAD infra-as-code/bicep/modules/managementGroups/managementGroups.bicep
-          git diff --name-only HEAD^ HEAD infra-as-code/bicep/modules/customRoleDefinitions/customRoleDefinitions.bicep
-          git diff --name-only HEAD^ HEAD infra-as-code/bicep/modules/policy/definitions/custom-policy-definitions.bicep
-          git diff --name-only HEAD^ HEAD infra-as-code/bicep/modules/policy/assignments/policyAssignmentManagementGroup.bicep
-          git diff --name-only HEAD^ HEAD infra-as-code/bicep/modules/subscriptionPlacement/subscriptionPlacement.bicep
-          git diff --name-only HEAD^ HEAD infra-as-code/bicep/modules/roleAssignments/roleAssignmentManagementGroup.bicep
-
-      - name: Check for logging Changes
-        id: git_logging_diff
-        shell: bash
-        run: |
-          git_logging=$(git diff --name-only HEAD^ HEAD infra-as-code/bicep/modules/logging/logging.bicep)
-          echo "gitLoggingOUTPUT=$git_logging"  >> $GITHUB_ENV
-
-      - name: Check for hubNetworking Changes
-        id: git_hubnetworking_diff
-        shell: bash
-        run: |
-          git_hub=$(git diff --name-only HEAD^ HEAD infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep)
-          echo "gitHubOUTPUT=$git_hub" >> $GITHUB_ENV
-
-      - name: Check for spokeNetworking Changes
-        id: git_spokenetworking_diff
-        shell: bash
-        run: |
-          git_spoke=$(git diff --name-only HEAD^ HEAD infra-as-code/bicep/modules/spokeNetworking/spokeNetworking.bicep)
-          echo "gitSpokeOUTPUT=$git_spoke" >> $GITHUB_ENV
-
-      - name: Az CLI Create Subscription for PR
-        id: create_subscription
-        if: ${{ steps.git_management_diff.outputs.diff != ''  }} || ${{ env.gitLoggingOUTPUT != '' }} || ${{ env.gitHubOUTPUT != ''  }} || ${{ env.gitSpokeOUTPUT != ''  }}
-        shell: bash
-        run: |
-            subid=$(az deployment tenant create --name "deploy-${{ env.SubscriptionName }}" --location ${{ env.Location }} --template-file infra-as-code/bicep/CRML/subscriptionAlias/subscriptionAlias.bicep --parameters @infra-as-code/bicep/CRML/subscriptionAlias/subscriptionAlias.parameters.example.json --parameters parSubscriptionBillingScope=${{ secrets.ALZ_AZURE_SECRET_EA_BILLING_ACCOUNT }} parSubscriptionName=${{ env.SubscriptionName }} | jq .properties.outputs.outSubscriptionId.value)
-            echo "SUBIDOUTPUT=$subid" >> $GITHUB_ENV
-
-      - name: Az CLI Refresh subscription list
-        id: refresh_subscription
-        if: ${{ steps.git_management_diff.outputs.diff != ''  }} || ${{ env.gitLoggingOUTPUT != '' }} || ${{ env.gitHubOUTPUT != ''  }} || ${{ env.gitSpokeOUTPUT != ''  }}
-        shell: bash
-        run: |
-            az account list --refresh
-            
-      - name: Az CLI Create Resource Group for PR
-        id: create_rsg
-        if: ${{ steps.git_management_diff.outputs.diff != '' }} || ${{ env.gitLoggingOUTPUT != '' }} || ${{ env.gitHubOUTPUT != '' }} || ${{ env.gitSpokeOUTPUT != '' }}
-        shell: bash
-        run: |
-            az account set --subscription ${{ env.SUBIDOUTPUT }}
-            if [ $(az group exists --name ${{ env.ResourceGroupName }} ) == false ]; then
-                sleep 300
-            fi
-            az group create --name ${{ env.ResourceGroupName }} --location ${{ env.Location }}
-
-      - name: Az CLI Deploy Management Groups for PR
-        id: create_mgs
-        shell: bash
-        run: |
-          if [[ ${{ steps.git_management_diff.outputs.diff != ''  }} ]] ; then
-            az deployment tenant create --template-file infra-as-code/bicep/modules/managementGroups/managementGroups.bicep --parameters parTopLevelManagementGroupPrefix=${{ env.ManagementGroupPrefix }} parTopLevelManagementGroupDisplayName="${{ env.TopLevelManagementGroupDisplayName }}" --location ${{ env.Location }}
-          fi
-          exit 0
-
-      - name: Az CLI Deploy Custom Role Definitions for PR
-        id: create_rbac_roles
-        if: ${{ steps.git_management_diff.outputs.diff != ''  }}
-        shell: bash
-        run: |
-            az deployment mg create --template-file infra-as-code/bicep/modules/customRoleDefinitions/customRoleDefinitions.bicep  --parameters @infra-as-code/bicep/modules/customRoleDefinitions/customRoleDefinitions.parameters.example.json --location ${{ env.Location }} --management-group-id ${{ env.ManagementGroupPrefix }}
-
-      - name: Az CLI Deploy Custom Policy Definitions for PR
-        id: create_policy_defs
-        if: ${{ steps.git_management_diff.outputs.diff != ''  }}
-        shell: bash
-        run: |
-            az deployment mg create --template-file infra-as-code/bicep/modules/policy/definitions/custom-policy-definitions.bicep  --parameters @infra-as-code/bicep/modules/policy/definitions/custom-policy-definitions.parameters.example.json --location ${{ env.Location }} --management-group-id ${{ env.ManagementGroupPrefix }}
-
-      - name: Az CLI Deploy Logging for PR
-        id: create_logging
-        if: ${{ env.gitLoggingOUTPUT != '' }}
-        shell: bash
-        run: |
-            az deployment group create --resource-group ${{ env.ResourceGroupName }} --template-file infra-as-code/bicep/modules/logging/logging.bicep --parameters @infra-as-code/bicep/modules/logging/logging.parameters.example.json
-
-      - name: Az CLI Policy Assignment DINE for PR
-        id: create_policy_assignment_dine
-        if: ${{ steps.git_management_diff.outputs.diff != ''  }}
-        shell: bash
-        run: |
-            az deployment mg create --template-file infra-as-code/bicep/modules/policy/assignments/policyAssignmentManagementGroup.bicep --parameters @infra-as-code/bicep/modules/policy/assignments/policyAssignmentManagementGroup.parameters.example-dine.json --location ${{ env.Location }} --management-group-id "${{ env.ManagementGroupPrefix }}-landingzones"
-            az deployment mg create --template-file infra-as-code/bicep/modules/roleAssignments/roleAssignmentManagementGroup.bicep --parameters @infra-as-code/bicep/modules/roleAssignments/roleAssignmentManagementGroup.parameters.service-principal.example.json --location ${{ env.Location }} --management-group-id "${{ env.ManagementGroupPrefix }}-platform"
-
-      - name: Az CLI Subscription Placement for PR
-        id: move_sub
-        if: ${{ steps.git_management_diff.outputs.diff != ''  }}
-        shell: bash
-        run: |
-            az deployment mg create --template-file infra-as-code/bicep/modules/subscriptionPlacement/subscriptionPlacement.bicep --parameters parTargetManagementGroupId=${{ env.ManagementGroupPrefix }} parSubscriptionIds='["${{env.SUBIDOUTPUT}}"]' --location ${{ env.Location }} --management-group-id ${{ env.ManagementGroupPrefix }}
-
-      - name: Az CLI Deploy Hub Networking for PR
-        id: create_hub_network
-        if: ${{ env.gitHubOUTPUT != ''  }}
-        shell: bash
-        run: |
-            az deployment group create --resource-group ${{ env.ResourceGroupName }} --template-file infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
-          
-      - name: Az CLI Deploy Spoke Networking for PR
-        id: create_spoke_network
-        if: ${{ env.gitSpokeOUTPUT != ''  }}
-        shell: bash
-        run: |
-            az deployment group create --resource-group ${{ env.ResourceGroupName }} --template-file infra-as-code/bicep/modules/spokeNetworking/spokeNetworking.bicep
-
-
-  bicep_cleanup:
-    name: Cleanup Bicep Deployment for PR
-    runs-on: ubuntu-latest
-    environment: BicepUnitTests
-    if: always()
-    needs: [bicep_deploy]
-
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.ALZ_AZURE_SECRET_UNIT_TESTS }}
-          enable-AzPSSession: true
-
-      - name: Az CLI Remove/Cleanup Deployment
-        if: needs.bicep_deploy.outputs.isDeployed
-        shell: pwsh
-        run: |
-            install-module -Name "Az.Accounts" -MinimumVersion "2.5.2" -Force
-            install-module -Name "Az.Resources" -MinimumVersion "4.3.0" -Force
-            install-module -Name "Az.ResourceGraph" -MinimumVersion "0.7.7"-Force
-            .github/scripts/Wipe-ESLZAzTenant.ps1 -tenantRootGroupID "${{ secrets.ALZ_AZURE_SECRET_TENANT_ID }}" -intermediateRootGroupID "${{ env.ManagementGroupPrefix }}" -subscriptionName "${{ env.SubscriptionName }}"

--- a/.github/workflows/cleanup-on-close-pr.yml
+++ b/.github/workflows/cleanup-on-close-pr.yml
@@ -1,5 +1,5 @@
 
-name: Close Pull Request
+name: Cancel Azure Subscription on PR Close
 
 # only trigger on pull request closed events
 on:
@@ -7,6 +7,7 @@ on:
     branches:
       - main
     types: [ closed ]
+
 env:
   SubscriptionName: "sub-unit-test-pr-${{ github.event.number }}"
   
@@ -26,43 +27,37 @@ jobs:
         creds: ${{ secrets.ALZ_AZURE_SECRET_UNIT_TESTS }}
         enable-AzPSSession: true
 
-    - name: Check if PR has associated subscription
-      uses: Azure/powershell@v1
-      with:
-        inlineScript: |
-            Install-Module -Name Az.Resources -Force
-            $subscription = Get-AzSubscription -SubscriptionName ${{ env.SubscriptionName }} -ErrorAction SilentlyContinue
-            If($subscription) {
-              echo "subscriptionId=$($subscription.Id)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-            }
-        azPSVersion: latest
+    - name: Check if PR has an associated Azure Subscription
+      shell: pwsh
+      run: |
+        Install-Module -Name Az.Resources -Force
+        $subscription = Get-AzSubscription -SubscriptionName ${{ env.SubscriptionName }} -ErrorAction SilentlyContinue
+        If($subscription) {
+          echo "subscriptionId=$($subscription.Id)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          Write-Information "==> Azure Subscription Found called: ${{ env.SubscriptionName }}" -InformationAction Continue
+        }
 
-    - name: Remove existing resource groups
+    - name: Remove existing Resource Groups in PR associated Azure Subscription
       if: ${{ env.subscriptionId != '' }}
-      uses: Azure/powershell@v1
-      with:
-        inlineScript: |
-            Select-AzSubscription -SubscriptionId ${{ env.subscriptionId }} 
-            $resourceGroups = @()
-            $resourceGroups += Get-AzResourceGroup
-            If ($resourceGroups.Count -gt 0) {
-                $resourceGroups | ForEach-Object -Parallel {
-                    Write-Information "Deleting resource group $($PSItem.ResourceGroupName)"
-                    Remove-AzResourceGroup -Name $PSItem.ResourceGroupName -Force
-                }
+      shell: pwsh
+      run: |
+        Select-AzSubscription -SubscriptionId ${{ env.subscriptionId }} 
+        $resourceGroups = @()
+        $resourceGroups += Get-AzResourceGroup
+        $resourceGroups | Select-Object -Property ResourceGroupName
+        If ($resourceGroups.Count -gt 0) {
+            $resourceGroups | ForEach-Object -Parallel {
+                Write-Information "==>Deleting resource group $($PSItem.ResourceGroupName)"
+                Remove-AzResourceGroup -Name $PSItem.ResourceGroupName -Force
             }
-        azPSVersion: latest
+        }
 
-    - name: Cancel PR Subscription
+    - name: Cancel PR associated Azure Subscription
       if: ${{ env.subscriptionId != '' }}
-      uses: Azure/powershell@v1
-      with:
-        inlineScript: |
-            Install-Module -Name Az.Subscription -Force
-            Write-Information "PR #${{ github.event.number }} has been merged" -InformationAction Continue
-            Write-Information "${{ env.SubscriptionName }} to be deleted" -InformationAction Continue
-            Update-AzSubscription -SubscriptionId ${{ env.subscriptionId }} -Action 'Cancel'
-        azPSVersion: latest
-
-
+      shell: pwsh
+      run: |
+        Install-Module -Name Az.Subscription -Force
+        Write-Information "==> PR #${{ github.event.number }} has been merged" -InformationAction Continue
+        Write-Information "==> ${{ env.SubscriptionName }} to be deleted" -InformationAction Continue
+        Update-AzSubscription -SubscriptionId ${{ env.subscriptionId }} -Action 'Cancel' -Debug -Confirm:$false
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR updates the unit tests for bicep files and the close PR job.

## This PR fixes/adds/changes/removes

1. Updated `.github\workflows\cleanup-on-close-pr.yml` to use standard shell instead of container based action outputs for more visibility into logs
2. Updated `.github\workflows\bicep-build-to-validate.yml` by removing deployment/E2E tests of modules as these will move to ADO shortly.
    -  These tests only now build the bicep files, and fail if any modules fail to build, and check against the bicep linter using the `bicepconfig.json` files in each module

### Breaking Changes

None

## Testing Evidence

Tests have just removed or converted existing functionality and commands they were using. Linters will confirm they are valid YAML files

Bicep Unit Tests - Tested Here: https://github.com/Azure/ALZ-Bicep/runs/5198665645?check_suite_focus=true

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
