### PR TITLE
Update parLogAnalyticsWorkspaceResourceID with empty string default value

### DIFF
--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
@@ -19,7 +19,7 @@ param parTopLevelManagementGroupPrefix string = 'alz'
 param parLogAnalyticsWorkSpaceAndAutomationAccountLocation string = 'eastus'
 
 @description('Log Analytics Workspace Resource ID. - DEFAULT VALUE: Empty String ')
-param parLogAnalyticsWorkspaceResourceID string = '/subscriptions/8200b669-cbc6-4e6c-b6d8-f4797f924074/resourceGroups/alz-logging/providers/Microsoft.OperationalInsights/workspaces/alz-log-analytics'
+param parLogAnalyticsWorkspaceResourceID string = ''
 
 @description('Number of days of log retention for Log Analytics Workspace. - DEFAULT VALUE: 365')
 param parLogAnalyticsWorkspaceLogRetentionInDays string = '365'


### PR DESCRIPTION
…alue

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Update parLogAnalyticsWorkspaceResourceID in alzDefaultPolicyAssignments.bicep with empty string default value

## This PR fixes/adds/changes/removes

1. Changes default value of parLogAnalyticsWorkspaceResourceID

### Breaking Changes

None

## Testing Evidence

Ran alzDefaultPolicyAssignmments deployment with empty string default value.

![image](https://user-images.githubusercontent.com/44706965/154142191-dae8c033-eb61-4e2c-9429-7bbf261fa4fe.png)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
