### PR TITLE
useRemoteGatewaysAdded property added to virtualNetworkPeer module

### DIFF
--- a/infra-as-code/bicep/modules/virtualNetworkPeer/README.md
+++ b/infra-as-code/bicep/modules/virtualNetworkPeer/README.md
@@ -23,6 +23,7 @@ The module requires the following inputs:
  | parAllowVirtualNetworkAccess     | bool   | true    | Switch to enable virtual Network Access                         | None                                         | true            |
  | parAllowForwardedTraffic         | bool   | true    | Switch to enable Forwarded Traffic                              | None                                         | true            |
  | parAllowGatewayTransit           | bool   | false   | Switch to enable Gateway Transit                                | None                                         | false           |
+ | parUseRemoteGateways             | bool   | false   | Switch to enable Remote Gateway                                 | None                                         | false           |
  | parTelemetryOptOut               | bool   | false   | Set Parameter to true to Opt-out of deployment telemetry        | None                                         | false           |
 
 ## Outputs

--- a/infra-as-code/bicep/modules/virtualNetworkPeer/virtualNetworkPeer.bicep
+++ b/infra-as-code/bicep/modules/virtualNetworkPeer/virtualNetworkPeer.bicep
@@ -3,8 +3,13 @@ SUMMARY: Module create network peer from one virtual network to another
 DESCRIPTION: The following components will be required parameters in this deployment
     parResourceGroupLocation
     parResourceGroupName
-AUTHOR/S: aultt
-VERSION: 1.0.0
+AUTHOR/S: aultt, KiZach
+VERSION: 1.1.0
+
+# Release notes 03/13/2022 - V1.1:
+    - Added support for useRemoteGateways property.
+    - Change is required to support a correct Hub/Spoke network peering with gateway support from spoke. 
+      Without the change Spoke netwotk will not be able to be peered and user VPN/ER from the Hub network.
 */
 
 @description('Virtual Network ID of Virtual Network destination. No default')
@@ -25,6 +30,9 @@ param parAllowForwardedTraffic bool = true
 @description('Switch to enable/disable forwarded Traffic for the Network Peer. Default = false')
 param parAllowGatewayTransit bool = false
 
+@description('Switch to enable/disable remote Gateway for the Network Peer. Default = false')
+param parUseRemoteGateways bool = false
+
 @description('Set Parameter to true to Opt-out of deployment telemetry')
 param parTelemetryOptOut bool = false
 
@@ -37,6 +45,7 @@ resource resVirtualNetworkPeer 'Microsoft.Network/virtualNetworks/virtualNetwork
     allowVirtualNetworkAccess: parAllowVirtualNetworkAccess
     allowForwardedTraffic: parAllowForwardedTraffic
     allowGatewayTransit: parAllowGatewayTransit
+    useRemoteGateways: parUseRemoteGateways
     remoteVirtualNetwork: {
       id: parDestinationVirtualNetworkID
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The virtualNetworkPeer module does not support the useRemoteGatewaysAdded property. This has been fixed.

## This PR fixes/adds/changes/removes

1. Adds useRemoteGatewaysAdded to the 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings' resource in the module.

### Breaking Changes

N/A

## Testing Evidence

Property has been added and tested with a standard Hub and Spoke setup.

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
