### PR TITLE
Output added to resourceGroup module.

### DIFF
--- a/infra-as-code/bicep/modules/resourceGroup/README.md
+++ b/infra-as-code/bicep/modules/resourceGroup/README.md
@@ -21,8 +21,10 @@ The module requires the following inputs:
 
 The module will generate the following outputs:
 
-| Output | Type | Example |
-| ------ | ---- | ------- |
+| Output                      | Type   | Example                                                                                                                                             |
+| --------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| outResourceGroupName | string | corp-hubservices-rg                                                                                                                                   |
+| outResourceGroupId    | string | /subscriptions/xxxxxxxx-xxxx-xxxx-xxxxx-xxxxxxxxx/resourceGroups/corp-hubservices-rg |
 
 ## Deployment
 

--- a/infra-as-code/bicep/modules/resourceGroup/resourceGroup.bicep
+++ b/infra-as-code/bicep/modules/resourceGroup/resourceGroup.bicep
@@ -3,8 +3,9 @@ SUMMARY: Module to deploy a resource group to the subscription specified.
 DESCRIPTION: The following components will be required parameters in this deployment
     parLocation
     parResourceGroupName
-AUTHOR/S: aultt
-VERSION: 1.0.0
+AUTHOR/S: aultt, KiZach
+VERSION: 1.0.1
+  - added outputs to make depends-on support better for sub modules deploying into the created resource group.
 */
 
 targetScope = 'subscription'
@@ -34,3 +35,6 @@ module modCustomerUsageAttribution '../../CRML/customerUsageAttribution/cuaIdSub
   name: 'pid-${varCuaid}-${uniqueString(subscription().subscriptionId, parResourceGroupName)}'
   params: {}
 }
+
+output outResourceGroupName string = resResourceGroup.name
+output outResourceGroupId string = resResourceGroup.id


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Added outputs to make depends-on support better for sub modules deploying into the created resource group.

## This PR fixes/adds/changes/removes

Support for using an output to make dependencies in bicep file.

### Breaking Changes

None

## Testing Evidence

Only adds output to module, so tested it with a simple main bicep file.

Inputs:
![image](https://user-images.githubusercontent.com/27825710/159733572-d724f9eb-b7de-492a-ba3a-6f427b65ec9f.png)

Outputs:
![image](https://user-images.githubusercontent.com/27825710/159733693-098ac081-f628-4f46-9f59-75e19425e6ad.png)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
