### PR TITLE
Fix ACR publish script

### DIFF
--- a/docs/scripts/createRGandcallBicep.ps1
+++ b/docs/scripts/createRGandcallBicep.ps1
@@ -1,6 +1,6 @@
 
 $azureResourceGroup='rsg-private-bicep-registry'
-$azureLocation='EastUs'
+$azureLocation='eastus'
 
 #Create resource group
 New-AzResourceGroup -Name $azureResourceGroup -Location $azureLocation
@@ -15,7 +15,7 @@ $azureContainerRegistryName=$deploymentOutput.Outputs.outLoginServer.Value
 #Leverage Powershell too loop through all bicep modules within the repository
 #convert the filename to lower case as Azure Container Registry doesnt support Camelcase
 #Leverage az bicep to publish module to Azure Container Registry created above
-$files = $(Get-ChildItem("$pwd/infra-as-code/bicep/modules/*/*.bicep"))
+$files = $(Get-ChildItem -path "$pwd/infra-as-code/bicep/modules" -Recurse -Include *.bicep -exclude *orch-hubSpoke.bicep)
 
 foreach ($file in $files)
 {

--- a/docs/scripts/createRGandcallBicep.sh
+++ b/docs/scripts/createRGandcallBicep.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 azureResourceGroup='rsg-private-bicep-registry'
-azureLocation='EastUs'
+azureLocation='eastus'
 
 #Create resource group
 az group create --name $azureResourceGroup --location $azureLocation
@@ -16,7 +16,7 @@ azureContainerRegistryName=$(az deployment group show -n deployACR -g $azureReso
 #Leverage Bash utilities too loop through all bicep modules within the repository
 #convert the filename to lower case as Azure Container Registry doesnt support Camelcase
 #Leverage az bicep to publish module to Azure Container Registry created above
-for file in infra-as-code/bicep/modules/*/*.bicep
+for file in $(find ./infra-as-code/bicep/modules -type f -name "*.bicep" ! -path "./infra-as-code/bicep/modules/unstable*")
 do
   f=$(echo "${file##*/}");
   filename=$(echo $f| cut  -d'.' -f 1| tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
# Overview/Summary

This pull request changes scripts used for ACR publish so that all modules are included, not just the upper levels. Described in https://github.com/Azure/ALZ-Bicep/issues/186

## This PR fixes/adds/changes/removes

1. Change docs/scripts/createRGandcallBicep.ps1 to do a recursive search for *.bicep files and exclude the orch-hubSpoke.bicep file. 
2. Change docs/scripts/createRGandcallBicep.sh to do a recursive search for *.bicep files and exclude files in ./infra-as-code/bicep/modules/unstable*.

### Breaking Changes

N/A

## Testing Evidence

Modules in ACR with existing Bash script.
![azcliold](https://user-images.githubusercontent.com/22591930/160614704-a3a38709-5942-4bc0-9d80-97ca8c68bf40.jpg)

Modules after running Bash script in this PR.
![azclinee1](https://user-images.githubusercontent.com/22591930/160615823-f6f69ecf-4d4e-48e2-a971-542a3e63fbed.jpg)
![azclinee2](https://user-images.githubusercontent.com/22591930/160615831-ea25e258-3bcc-4c25-843f-512453e9b5cd.jpg)

Modules in ACR with existing PowerShell script.
![psold](https://user-images.githubusercontent.com/22591930/160614887-de08d3e5-f575-4816-8b3f-d7603aecbcaf.jpg)

Modules after running PowerShell script in this PR.
![psnew1](https://user-images.githubusercontent.com/22591930/160614987-44bef97e-ae5b-43ca-a679-57fae35ad4cb.jpg)
![psnew2](https://user-images.githubusercontent.com/22591930/160615003-9360cfac-0cd3-4d67-a6e3-bf535d0756f4.jpg)





## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_workitems/edit/103877)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [] Updated relevant and associated documentation.
