### PR TITLE
Initial PSRule without parameter files #206

### DIFF
--- a/.github/workflows/bicep-build-to-validate.yml
+++ b/.github/workflows/bicep-build-to-validate.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+
+      # TODO: Branch for integration testing, to be removed before integration into main.
+      - ps-rule
     paths:
       - "**.bicep"
   workflow_dispatch: {}
@@ -34,3 +37,11 @@ jobs:
                 echo $output
               }   
           }
+
+      # Add pipeline tests for Azure Well-Architected Framework
+      - name: Run PSRule analysis
+        uses: Microsoft/ps-rule@v2.0.0
+        with:
+          modules: PSRule.Rules.Azure
+          baseline: Azure.GA_2022_03
+        continue-on-error: true

--- a/.github/workflows/bicep-build-to-validate.yml
+++ b/.github/workflows/bicep-build-to-validate.yml
@@ -9,6 +9,8 @@ on:
       - ps-rule
     paths:
       - "**.bicep"
+      - "ps-rule.yaml"
+      - ".ps-rule/*"
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/bicep-build-to-validate.yml
+++ b/.github/workflows/bicep-build-to-validate.yml
@@ -40,6 +40,17 @@ jobs:
               }   
           }
 
+  azure_waf:
+    name: Test Azure Well-Architected Framework
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       # Add pipeline tests for Azure Well-Architected Framework
       - name: Run PSRule analysis
         uses: Microsoft/ps-rule@v2.0.0

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-azuretools.vscode-bicep",
+        "bewhite.psrule-vscode"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "PSRule",
+            "problemMatcher": [
+                "$PSRule"
+            ],
+            "label": "PSRule: Run analysis",
+            "presentation": {
+                "panel": "dedicated",
+                "clear": true
+            }
+        }
+    ]
+}

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -55,6 +55,7 @@ The following tooling/extensions are recommended to assist you developing for th
 - [CodeTour extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour)
 - [ARM Tools extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=msazurermtools.azurerm-vscode-tools)
 - [ARM Template Viewer extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=bencoleman.armview)
+- [PSRule extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=bewhite.psrule-vscode)
 - For visibility of Bracket Pairs:
   - Use an Extension: [Bracket Pair Colorizer 2 extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2)
   - Use Native capability:

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -47,8 +47,8 @@ input:
   - 'infra-as-code/bicep/modules/**/*.bicep'
   - 'infra-as-code/bicep/CRML/**/*.bicep'
 
-  # Include test files from modules
-  - '!infra-as-code/bicep/modules/**/*.tests.bicep'
+  # Include samples/ test files from modules
+  - '!infra-as-code/bicep/modules/**/samples/*.bicep'
 
 rule:
   exclude:

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -1,0 +1,59 @@
+#
+# PSRule for Azure configuration
+#
+
+# Please see the documentation for all configuration options:
+# https://aka.ms/ps-rule-azure
+
+# Use rules from the following modules/
+include:
+  module:
+  - 'PSRule.Rules.Azure'
+
+# Require a minimum version of modules that include referenced baseline.
+requires:
+  PSRule.Rules.Azure: '@pre >=1.14.2'
+
+# Reference the repository in output.
+repository:
+  url: https://github.com/Azure/ALZ-Bicep
+
+execution:
+  # Ignore warnings for resources and objects that don't have any rules.
+  notProcessedWarning: false
+
+configuration:
+  # Enable expansion for Bicep source files.
+  AZURE_BICEP_FILE_EXPANSION: true
+
+  # Expand Bicep module from Azure parameter files.
+  AZURE_PARAMETER_FILE_EXPANSION: true
+
+  # Set timeout for expanding Bicep source files.
+  AZURE_BICEP_FILE_EXPANSION_TIMEOUT: 15
+
+input:
+  pathIgnore:
+  # Ignore common files that don't need analysis.
+  - '**/bicepconfig.json'
+  - '*.md'
+  - '*.png'
+  - '.github/'
+
+  # Exclude Bicep docs files
+  - docs/scripts/callModuleFromACR.example.bicep
+
+  # Exclude Bicep module files
+  - 'infra-as-code/bicep/modules/**/*.bicep'
+  - 'infra-as-code/bicep/CRML/**/*.bicep'
+
+  # Include test files from modules
+  - '!infra-as-code/bicep/modules/**/*.tests.bicep'
+
+rule:
+  exclude:
+  # Ignore these recommendations for this repo.
+  - Azure.Resource.UseTags
+  - Azure.ACR.MinSku
+  - Azure.ACR.ContentTrust
+  - Azure.Policy.AssignmentAssignedBy


### PR DESCRIPTION
# Overview/Summary

Adds integration with PSRule for Azure for testing repository code with Azure Well-Architected Framework.

Working towards #206 

## This PR fixes/adds/changes/removes

1. Added PSRule integration using VSCode and GitHub Actions. Parameter files/ Bicep tests not included.

### Breaking Changes

N/A

## Testing Evidence

Modules resources are not being processed yet until we have snippets to expand them.

```text
Rules processed: 124, failed: 0, errored: 0
Run Azure/ALZ-Bicep/2170788848 completed in 00:00:07.1681704
```

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [ADO items](https://dev.azure.com/unifiedactiontracker/Solution%20Engineering/_backlogs/backlog/Azure%20Landing%20Zone%20Bicep/Backlog%20Bugs%20Feedback)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
