### PR TITLE
remove deprecated extension from Contributing guide - Backlog Item 110091

### DIFF
--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -55,7 +55,8 @@ The following tooling/extensions are recommended to assist you developing for th
 - [CodeTour extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour)
 - [ARM Tools extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=msazurermtools.azurerm-vscode-tools)
 - [ARM Template Viewer extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=bencoleman.armview)
-
+- For visibility of Bracket Pairs:
+  - Inside Visual Studio Code, add "editor.bracketPairColorization.enabled": true to your settings.json, to enable bracket pair colorization.
 
 ## Bicep Formatting Guidelines
 

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -55,10 +55,7 @@ The following tooling/extensions are recommended to assist you developing for th
 - [CodeTour extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour)
 - [ARM Tools extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=msazurermtools.azurerm-vscode-tools)
 - [ARM Template Viewer extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=bencoleman.armview)
-- For visibility of Bracket Pairs:
-  - Use an Extension: [Bracket Pair Colorizer 2 extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2)
-  - Use Native capability:
-    - Inside Visual Studio Code, add `"editor.bracketPairColorization.enabled": true` to your settings.json, to enable bracket pair colorization.
+
 
 ## Bicep Formatting Guidelines
 


### PR DESCRIPTION
# Overview/Summary

Removal of deprecated extension from Contributing guide

## This PR fixes/adds/changes/removes

1. Removed the deprecated extension from the Contributing guide

### Breaking Changes

1. Removed the deprecated extension from the Contributing guide. No technical changes aside from extension recommendation

## Testing Evidence

![image](https://user-images.githubusercontent.com/53943045/165909449-de98a602-313e-4f42-9fa4-c6c24679e064.png)

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [N/A] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [X] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [X] Performed testing and provided evidence.
- [N/A] Updated tests *(if required)* [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml) - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows) - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [N/A] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
