### PR TITLE
Fix markdown link check github docs 403

### DIFF
--- a/.github/actions-config/mlc_config.json
+++ b/.github/actions-config/mlc_config.json
@@ -1,6 +1,27 @@
 {
+  "ignorePatterns": [
+    {
+      "pattern": "^http://localhost"
+    }
+  ],
+  "httpHeaders": [
+    {
+      "comment": "Workaround as suggested here: https://github.com/tcort/markdown-link-check/issues/201",
+      "urls": [
+        "https://docs.github.com/"
+      ],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ],
+  "timeout": "5s",
+  "retryOn429": true,
+  "retryCount": 5,
+  "fallbackRetryDelay": "30s",
   "aliveStatusCodes": [
     200,
-    203
+    203,
+    206
   ]
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixing 403 errors for GitHub Docs causing Markdown Link Checks to fail incorrectly.

Fix found here: https://github.com/tcort/markdown-link-check/issues/201

## This PR fixes/adds/changes/removes

1. Fixing 403 errors for GitHub Docs causing Markdown Link Checks to fail incorrectly.

### Breaking Changes

None

## Testing Evidence

If markdown link check passes on this PR this is the evidence

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated tests *(if required)* [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml) - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows) - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [x] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
