### PR TITLE
Added tag property for virtualNetworks resource

### DIFF
--- a/infra-as-code/bicep/modules/spokeNetworking/spokeNetworking.bicep
+++ b/infra-as-code/bicep/modules/spokeNetworking/spokeNetworking.bicep
@@ -36,6 +36,7 @@ var varCuaid = '0c428583-f2a1-4448-975c-2d6262fd193a'
 resource resSpokeVirtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
   name: parSpokeNetworkName
   location: parLocation
+  tags: parTags
   properties: {
     addressSpace: {
       addressPrefixes: [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Found out that I was missing the tag property during template testing.

## This PR fixes/adds/changes/removes

1. Added parTags to the virtualNetwork resource in spokeNetworking.bicep

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated tests *(if required)* [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml) - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows) - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
