### PR TITLE
Description updates, consistency usage of camelCasing (vnetPeering)

### DIFF
--- a/infra-as-code/bicep/modules/vnetPeering/README.md
+++ b/infra-as-code/bicep/modules/vnetPeering/README.md
@@ -17,7 +17,7 @@ The module requires the following inputs:
 
  | Parameter                        | Type   | Default | Description                                                     | Requirement                                  | Example         |
  | -------------------------------- | ------ | ------- | --------------------------------------------------------------- | -------------------------------------------- | --------------- |
- | parDestinationVirtualNetworkID   | string | None    | ID of the Destination Virtual Network                           | Valid Virtual Network ID                     |
+ | parDestinationVirtualNetworkId   | string | None    | ID of the Destination Virtual Network                           | Valid Virtual Network ID                     |
  | parSourceVirtualNetworkName      | string | None    | Name of Source Virtual Network                                  | Valid Azure Region                           | alz-spk-eastus2 |
  | parDestinationVirtualNetworkName | string | None    | Virtual Network Name of the destination/target Virtual Network. | 2-64 char, letters, numbers, and underscores | alz-hub-eastus2 |
  | parAllowVirtualNetworkAccess     | bool   | true    | Switch to enable virtual Network Access                         | None                                         | true            |

--- a/infra-as-code/bicep/modules/vnetPeering/vnetPeering.bicep
+++ b/infra-as-code/bicep/modules/vnetPeering/vnetPeering.bicep
@@ -1,29 +1,29 @@
 @description('Virtual Network ID of Virtual Network destination. No default')
-param parDestinationVirtualNetworkID string
+param parDestinationVirtualNetworkId string
 
 @description('Name of source Virtual Network we are peering. No default')
 param parSourceVirtualNetworkName string
 
-@description('Name of destination virtual network we are peering.  No Default')
+@description('Name of destination virtual network we are peering. No default')
 param parDestinationVirtualNetworkName string
 
 @description('Switch to enable/disable Virtual Network Access for the Network Peer. Default = true')
 param parAllowVirtualNetworkAccess bool = true
 
-@description('Switch to enable/disable forwarded Traffic for the Network Peer. Default = true')
+@description('Switch to enable/disable forwarded traffic for the Network Peer. Default = true')
 param parAllowForwardedTraffic bool = true
 
-@description('Switch to enable/disable forwarded Traffic for the Network Peer. Default = false')
+@description('Switch to enable/disable gateway transit for the Network Peer. Default = false')
 param parAllowGatewayTransit bool = false
 
-@description('Switch to enable/disable remote Gateway for the Network Peer. Default = false')
+@description('Switch to enable/disable remote gateway for the Network Peer. Default = false')
 param parUseRemoteGateways bool = false
 
-@description('Set Parameter to true to Opt-out of deployment telemetry')
+@description('Set Parameter to true to Opt-out of deployment telemetry. Default = false')
 param parTelemetryOptOut bool = false
 
 // Customer Usage Attribution Id
-var varCuaid = 'ab8e3b12-b0fa-40aa-8630-e3f7699e2142'
+var varCuaId = 'ab8e3b12-b0fa-40aa-8630-e3f7699e2142'
 
 resource resVirtualNetworkPeer 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-11-01' = {
   name: '${parSourceVirtualNetworkName}/peer-to-${parDestinationVirtualNetworkName}'
@@ -33,7 +33,7 @@ resource resVirtualNetworkPeer 'Microsoft.Network/virtualNetworks/virtualNetwork
     allowGatewayTransit: parAllowGatewayTransit
     useRemoteGateways: parUseRemoteGateways
     remoteVirtualNetwork: {
-      id: parDestinationVirtualNetworkID
+      id: parDestinationVirtualNetworkId
     }
   }
 }
@@ -41,6 +41,6 @@ resource resVirtualNetworkPeer 'Microsoft.Network/virtualNetworks/virtualNetwork
 // Optional Deployment for Customer Usage Attribution
 module modCustomerUsageAttribution '../../CRML/customerUsageAttribution/cuaIdResourceGroup.bicep' = if (!parTelemetryOptOut) {
   #disable-next-line no-loc-expr-outside-params //Only to ensure telemetry data is stored in same location as deployment. See https://github.com/Azure/ALZ-Bicep/wiki/FAQ#why-are-some-linter-rules-disabled-via-the-disable-next-line-bicep-function for more information
-  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  name: 'pid-${varCuaId}-${uniqueString(resourceGroup().location)}'
   params: {}
 }

--- a/infra-as-code/bicep/modules/vnetPeering/vnetPeering.parameters.example.json
+++ b/infra-as-code/bicep/modules/vnetPeering/vnetPeering.parameters.example.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "parDestinationVirtualNetworkID": {
+    "parDestinationVirtualNetworkId": {
       "value": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/HUB_Networking_POC/providers/Microsoft.Network/virtualNetworks/alz-hub-eastus"
     },
     "parSourceVirtualNetworkName": {

--- a/infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep
+++ b/infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep
@@ -153,7 +153,7 @@ module modHubPeeringToSpoke '../../modules/vnetPeering/vnetPeering.bicep' = if (
   scope: resourceGroup(varHubVirtualNetworkSubscriptionId,varHubVirtualNetworkResourceGroup)
   name: varModuleDeploymentNames.modSpokePeeringFromHub
   params: {
-    parDestinationVirtualNetworkID: (!empty(varHubVirtualNetworkName) ? modSpokeNetworking.outputs.outSpokeVirtualNetworkId : '')
+    parDestinationVirtualNetworkId: (!empty(varHubVirtualNetworkName) ? modSpokeNetworking.outputs.outSpokeVirtualNetworkId : '')
     parDestinationVirtualNetworkName: (!empty(varHubVirtualNetworkName) ? modSpokeNetworking.outputs.outSpokeVirtualNetworkName : '')
     parSourceVirtualNetworkName: varHubVirtualNetworkName
     parAllowForwardedTraffic: parAllowSpokeForwardedTraffic
@@ -167,7 +167,7 @@ module modSpokePeeringToHub '../../modules/vnetPeering/vnetPeering.bicep' = if (
   scope: resourceGroup(parPeeredVnetSubscriptionId,parResourceGroupNameForSpokeNetworking)
   name: varModuleDeploymentNames.modSpokePeeringToHub
   params: {
-    parDestinationVirtualNetworkID: parHubVirtualNetworkId
+    parDestinationVirtualNetworkId: parHubVirtualNetworkId
     parDestinationVirtualNetworkName: varHubVirtualNetworkName
     parSourceVirtualNetworkName: (!empty(varHubVirtualNetworkName) ? modSpokeNetworking.outputs.outSpokeVirtualNetworkName : '')
     parUseRemoteGateways: parAllowHubVpnGatewayTransit

--- a/tests/pipelines/bicep-build-to-validate.yml
+++ b/tests/pipelines/bicep-build-to-validate.yml
@@ -234,7 +234,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        az deployment group create --resource-group $(ResourceGroupName) --template-file infra-as-code/bicep/modules/vnetPeering/vnetPeering.bicep --parameters @infra-as-code/bicep/modules/vnetPeering/vnetPeering.parameters.example.json parDestinationVirtualNetworkID="/subscriptions/$(subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.Network/virtualNetworks/alz-hub-eastus"
+        az deployment group create --resource-group $(ResourceGroupName) --template-file infra-as-code/bicep/modules/vnetPeering/vnetPeering.bicep --parameters @infra-as-code/bicep/modules/vnetPeering/vnetPeering.parameters.example.json parDestinationVirtualNetworkId="/subscriptions/$(subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.Network/virtualNetworks/alz-hub-eastus"
 
   - task: Bash@3    
     displayName: Az CLI Deploy vNet Peer for PR hub to spoke
@@ -243,7 +243,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        az deployment group create --resource-group $(ResourceGroupName) --template-file infra-as-code/bicep/modules/vnetPeering/vnetPeering.bicep --parameters @infra-as-code/bicep/modules/vnetPeering/vnetPeering.parameters.example.json parDestinationVirtualNetworkID="/subscriptions/$(subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.Network/virtualNetworks/vnet-spoke" parSourceVirtualNetworkName="alz-hub-eastus" parDestinationVirtualNetworkName="vnet-spoke"
+        az deployment group create --resource-group $(ResourceGroupName) --template-file infra-as-code/bicep/modules/vnetPeering/vnetPeering.bicep --parameters @infra-as-code/bicep/modules/vnetPeering/vnetPeering.parameters.example.json parDestinationVirtualNetworkId="/subscriptions/$(subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.Network/virtualNetworks/vnet-spoke" parSourceVirtualNetworkName="alz-hub-eastus" parDestinationVirtualNetworkName="vnet-spoke"
 
 - job: bicep_cleanup
   dependsOn: bicep_deploy


### PR DESCRIPTION
# Overview/Summary

- Description update for `parAllowGatewayTransit`, added default value for `parTelemetryOptOut`
- camelCasing for `varCuaId` and `parDestinationVirtualNetworkId` (in Bicep template, readme and parameter file)

### Breaking Changes

- `parDestinationVirtualNetworkID` to `parDestinationVirtualNetworkId`

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated tests *(if required)* [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml) - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows) - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
