### PR TITLE
Remove subscription selection from hubPeeredSpoke module readme

### DIFF
--- a/infra-as-code/bicep/orchestration/hubPeeredSpoke/README.md
+++ b/infra-as-code/bicep/orchestration/hubPeeredSpoke/README.md
@@ -57,10 +57,6 @@ In this example, the spoke resources will be deployed to the resource group spec
 ### Azure CLI
 ```bash
 # For Azure global regions
-# Set Azure Corp Landing zone subscription ID as the the current subscription 
-LandingZoneSubscriptionId="[your landing zone subscription ID]"
-az account set --subscription $LandingZoneSubscriptionId
-
 az deployment mg create \
     --template-file infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep \
     --parameters @infra-as-code/bicep/orchestration/hubPeeredSpoke/parameters/hubPeeredSpoke.parameters.all.json \
@@ -70,10 +66,6 @@ az deployment mg create \
 OR
 ```bash
 # For Azure China regions
-# Set Azure Corp Landing zone subscription ID as the the current subscription
-LandingZoneSubscriptionId="[your landing zone subscription ID]"
-az account set --subscription $LandingZoneSubscriptionId
-
 az deployment mg create \
     --template-file infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep \
     --parameters @infra-as-code/bicep/orchestration/hubPeeredSpoke/parameters/hubPeeredSpoke.parameters.all.json \
@@ -85,10 +77,6 @@ az deployment mg create \
 
 ```powershell
 # For Azure global regions
-# Set Azure Corp Landing zone subscription ID as the the current subscription 
-$LandingZoneSubscriptionId="[your landing zone subscription ID]"
-Select-AzSubscription -SubscriptionId $LandingZoneSubscriptionId
-  
 New-AzManagementGroupDeployment `
   -TemplateFile infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep `
   -TemplateParameterFile infra-as-code/bicep/orchestration/hubPeeredSpoke/parameters/hubPeeredSpoke.parameters.all.json `
@@ -98,12 +86,6 @@ New-AzManagementGroupDeployment `
 OR
 ```powershell
 # For Azure China regions
-# Set Platform connectivity subscription ID as the the current subscription 
-$LandingZoneSubscriptionId="[your landing zone subscription ID]"
-$TopLevelManagemetGroupID="alz"
-
-Select-AzSubscription -SubscriptionId $LandingZoneSubscriptionId
-  
 New-AzManagementGroupDeployment `
   -TemplateFile infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep `
   -TemplateParameterFile infra-as-code/bicep/orchestration/hubPeeredSpoke/parameters/hubPeeredSpoke.parameters.all.json `


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fix for issue #270 

## This PR fixes/adds/changes/removes

1. removes subscription selection for various command flavors.

### Breaking Changes

None

## Testing Evidence

Not relevant documentation only.

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
