### PR TITLE
Fixed typos

### DIFF
--- a/infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep
+++ b/infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep
@@ -2,7 +2,7 @@ targetScope = 'managementGroup'
 
 // **Parameters**
 // Generic Parameters - Used in multiple modules
-@description('The region to deploy all resoruces into. DEFAULTS TO deployment().location')
+@description('The region to deploy all resources into. DEFAULTS TO deployment().location')
 param parLocation string = deployment().location
 
 @description('Prefix for the management group hierarchy. DEFAULTS TO = alz')
@@ -95,7 +95,7 @@ var varVirtualHubResourceGroup = (!empty(parHubVirtualNetworkId) && contains(par
 var varVirtualHubSubscriptionId = (!empty(parHubVirtualNetworkId) && contains(parHubVirtualNetworkId, '/providers/Microsoft.Network/virtualHubs/') ? split(parHubVirtualNetworkId, '/')[2] : '' )
 
 // **Modules**
-// Module - Customer Usage Attribution - Telemtry
+// Module - Customer Usage Attribution - Telemetry
 module modCustomerUsageAttribution '../../CRML/customerUsageAttribution/cuaIdManagementGroup.bicep' = if (!parTelemetryOptOut) {
   scope: managementGroup(parTopLevelManagementGroupPrefix)
   name: 'pid-${varCuaid}-${uniqueString(parLocation, parPeeredVnetSubscriptionId)}'


### PR DESCRIPTION
"Resources" and "telemetry" updated with proper spelling

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Typos in hubPeeredSpoke module

### Breaking Changes

None

## Testing Evidence

Linting will suffice

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
