### PR TITLE
doc: Added subnet disclaimer

### DIFF
--- a/infra-as-code/bicep/modules/spokeNetworking/README.md
+++ b/infra-as-code/bicep/modules/spokeNetworking/README.md
@@ -9,9 +9,10 @@ Module deploys the following resources:
 
 > Consider using the `hubPeeredSpoke` orchestration module instead to simplify spoke networking deployment, VNET Peering, UDR configuration and Subscription placement in a single module. [infra-as-code/bicep/orchestration/hubPeeredSpoke](https://github.com/Azure/ALZ-Bicep/tree/main/infra-as-code/bicep/orchestration/hubPeeredSpoke)
 
-> #### NOTE
+> ## NOTE
 >
 > This module only deploys the skeleton of a virtual network. Subnet(s) are not created nor does this module support declaring them. This is a blank vNet with the expectation of handing it over to the app/workload team to create their subnet(s), etc. The ALZ-Bicep core team decided not to add subnet support due to:
+>
 > - Complexity of managing all of the subnet properties, including NSG, UDR, service endpoints, subnet delegations, etc.
 > - Intellisense will be a challenge as we'll be using an array of objects to define the subnet properties
 > - Feature parity with ALZ Azure Portal and Terraform experience

--- a/infra-as-code/bicep/modules/spokeNetworking/README.md
+++ b/infra-as-code/bicep/modules/spokeNetworking/README.md
@@ -7,9 +7,13 @@ Module deploys the following resources:
 - Virtual Network (Spoke VNet)
 - UDR - if Firewall is enabled
 
+> ## Note
+>
+> ### Orchestration
+>
 > Consider using the `hubPeeredSpoke` orchestration module instead to simplify spoke networking deployment, VNET Peering, UDR configuration and Subscription placement in a single module. [infra-as-code/bicep/orchestration/hubPeeredSpoke](https://github.com/Azure/ALZ-Bicep/tree/main/infra-as-code/bicep/orchestration/hubPeeredSpoke)
-
-> ## NOTE
+>
+> ### Subnet Declaration
 >
 > This module only deploys the skeleton of a virtual network. Subnet(s) are not created nor does this module support declaring them. This is a blank vNet with the expectation of handing it over to the app/workload team to create their subnet(s), etc. The ALZ-Bicep core team decided not to add subnet support due to:
 >

--- a/infra-as-code/bicep/modules/spokeNetworking/README.md
+++ b/infra-as-code/bicep/modules/spokeNetworking/README.md
@@ -9,6 +9,20 @@ Module deploys the following resources:
 
 > Consider using the `hubPeeredSpoke` orchestration module instead to simplify spoke networking deployment, VNET Peering, UDR configuration and Subscription placement in a single module. [infra-as-code/bicep/orchestration/hubPeeredSpoke](https://github.com/Azure/ALZ-Bicep/tree/main/infra-as-code/bicep/orchestration/hubPeeredSpoke)
 
+> #### NOTE
+>
+> This module only deploys the skeleton of a virtual network. Subnet(s) are not created nor does this module support declaring them. This is a blank vNet with the expectation of handing it over to the app/workload team to create their subnet(s), etc. The ALZ-Bicep core team decided not to add subnet support due to:
+> - Complexity of managing all of the subnet properties, including NSG, UDR, service endpoints, subnet delegations, etc.
+> - Intellisense will be a challenge as we'll be using an array of objects to define the subnet properties
+> - Feature parity with ALZ Azure Portal and Terraform experience
+> - Future updates to the virtual network resource provider could change the way we manage subnets as a child and/or a separate resource object. All to say this future change could make it easier to manage a subnet declaration within this module
+>
+> To customize spoke networking to include subnet declarations, we recommend the use of the following ordered methods:
+>
+> 1. [CARML](https://aka.ms/carml) - Utilize this mature Bicep repo for resource deployments
+> 2. [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) this repo and customize the modules accordingly
+> 3. Write your own custom module
+
 ## Parameters
 
 The module requires the following inputs:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Added a disclaimer about the spokeNetworking.bicep module and how it deploys a blank vNet. Also included guidance for utilizing CARML or other techniques for supporting subnet declaration. 

## This PR fixes/adds/changes/removes

1. Closes #301

### Breaking Changes

1. Only updating readme.md file

## Testing Evidence

Only textual changes

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
