### PR TITLE
capture definitionReferenceId that starts with number.

### DIFF
--- a/.github/scripts/Invoke-PolicyToBicep.ps1
+++ b/.github/scripts/Invoke-PolicyToBicep.ps1
@@ -162,7 +162,7 @@ function New-PolicySetDefinitionsBicepInputTxtFile {
                 }
 
                 # If definitionReferenceId contains, then wrap in definitionReferenceId value in [] to comply with bicep formatting
-                if ($definitionReferenceIdForParameters.Contains("-") -or $definitionReferenceIdForParameters.Contains(" ") -or $definitionReferenceIdForParameters.Contains("\'")) {
+                if ($definitionReferenceIdForParameters.Contains("-") -or $definitionReferenceIdForParameters.Contains(" ") -or $definitionReferenceIdForParameters.Contains("\'") -or $definitionReferenceIdForParameters -match '^[0-9].+') {
                     $definitionReferenceIdForParameters = "['$definitionReferenceIdForParameters']"
 
                     # Add nested array of objects to each Policy Set/Initiative Definition in the Bicep variable, without the '.' before the definitionReferenceId to make it an accessor


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

We (slz engineering team) found an issue in alz's invoke-policyToBicep.ps1. This script doesn't support any definitionReferenceId that starts with number. E.g. We have a policySet definitions that pulled from azure built-in policy, the definitionReferenceId is like '10006169408036501401'. The invoke-policyToBicep.ps1 generates _policySetDefintionsBicepInput.txt like this.
![image](https://user-images.githubusercontent.com/5110396/193200159-089f2008-0a0f-4806-b759-d407bf9ea3c3.png)
It uses `.10006169408036501401` to reference an object which is illegals for neither json nor bicep. The invoke-policyToBicep.ps1 somehow missed to handle this case. 

## This PR fixes/adds/changes/removes

1. adding a regex to capture defintionReferenceId that starts with number.
`$definitionReferenceIdForParameters -match '^[0-9].+'`
### Breaking Changes

N/A

## Testing Evidence

with this pr, we can see the result diff in the output of the invoke-PolicyToBicep.ps1
![image](https://user-images.githubusercontent.com/5110396/193200950-d0a8c3a0-4c27-44b5-99fc-f111940327d5.png)


## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [X] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [X] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [X] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
