### PR TITLE
Fix bicep example for parLandingZoneMgChildren

### DIFF
--- a/infra-as-code/bicep/orchestration/mgDiagSettingsAll/README.md
+++ b/infra-as-code/bicep/orchestration/mgDiagSettingsAll/README.md
@@ -50,14 +50,10 @@ Below are some examples of how to use this input parameter in both Bicep & JSON 
 ##### Bicep Example
 
 ```bicep
-parLandingZoneMgChildren: {
-  pci: {
-    displayName: 'PCI'
-  }
-  'another-example': {
-    displayName: 'Another Example'
-  }
-}
+parLandingZoneMgChildren: [
+    'pci'
+    'another-example'
+]
 ```
 
 ##### JSON Parameter File Input Example


### PR DESCRIPTION
# Overview/Summary

Fix invalid bicep example in documentations for `mgDiagSettingsAll`

## This PR fixes/adds/changes/removes

1. Fixes #354

### Breaking Changes

None

## Testing Evidence

N/A

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [X] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
