### PR TITLE
Feature: Add ability to exclude policy set/initiative child definitions for China policies

### DIFF
--- a/.github/scripts/Invoke-PolicyToBicep-China.ps1
+++ b/.github/scripts/Invoke-PolicyToBicep-China.ps1
@@ -37,7 +37,9 @@ param (
   [string]
   $defintionsSetTxtFileName = "_mc_policySetDefinitionsBicepInput.txt",
   [string]
-  $assignmentsTxtFileName = "_mc_policyAssignmentsBicepInput.txt"
+  $assignmentsTxtFileName = "_mc_policyAssignmentsBicepInput.txt",
+  [array]
+  $excludedPolicySetChildDefinitionsReferenceIds = @("AVDHostPoolsDeployDiagnosticLogDeployLogAnalytics", "defenderForSqlServerVirtualMachines", "defenderForOssDb", "defenderForCosmosDbs", "defenderForAppServices", "defenderForStorageAccounts", "defenderForKeyVaults")
 )
 
 # This script relies on a custom set of classes and functions
@@ -129,19 +131,26 @@ function New-PolicySetDefinitionsBicepInputTxtFile {
         $definitionReferenceId = $_.policyDefinitionReferenceId
         $definitionParameters = $_.parameters
 
-        if ($definitionParameters) {
-          $definitionParameters | Sort-Object | ForEach-Object {
-            [System.Collections.Hashtable]$definitionParametersOutputArray = [ordered]@{}
-            $definitionParametersOutputArray.Add("parameters", $_)
+        if ($definitionReferenceId -notin $excludedPolicySetChildDefinitionsReferenceIds) {
+
+          if ($definitionParameters) {
+            $definitionParameters | Sort-Object | ForEach-Object {
+              [System.Collections.Hashtable]$definitionParametersOutputArray = [ordered]@{}
+              $definitionParametersOutputArray.Add("parameters", $_)
+            }
           }
+          else {
+            [System.Collections.Hashtable]$definitionParametersOutputArray = [ordered]@{}
+            $definitionParametersOutputArray.Add("parameters", @{})
+          }
+
+          $definitionParametersOutputJSONObject.Add("$definitionReferenceId", $definitionParametersOutputArray)
         }
         else {
-          [System.Collections.Hashtable]$definitionParametersOutputArray = [ordered]@{}
-          $definitionParametersOutputArray.Add("parameters", @{})
+          Write-Information "==> Skipping '$definitionReferenceId' as it is in the excluded list" -InformationAction Continue
         }
-
-        $definitionParametersOutputJSONObject.Add("$definitionReferenceId", $definitionParametersOutputArray)
       }
+
       Write-Information "==> Adding parameters to '$parametersFileName'" -InformationAction Continue
       Add-Content -Path "$rootPath/$definitionsSetLongPath/$parametersFileName" -Value ($definitionParametersOutputJSONObject | ConvertTo-Json -Depth 10) -Encoding "utf8"
 
@@ -193,25 +202,31 @@ function New-PolicySetDefinitionsBicepInputTxtFile {
           $definitionId = $($policySetDefinitionsOutputForBicep[$_][0])
           $groups = $($policySetDefinitionsOutputForBicep[$_][1])
 
-          # If definitionReferenceId or definitionReferenceIdForParameters contains apostrophes, replace that apostrophe with a backslash and an apostrohphe for Bicep string escaping
-          if ($definitionReferenceId.Contains("'")) {
-            $definitionReferenceId = $definitionReferenceId.Replace("'", "\'")
-          }
+          if ($definitionReferenceId -notin $excludedPolicySetChildDefinitionsReferenceIds) {
 
-          if ($definitionReferenceIdForParameters.Contains("'")) {
-            $definitionReferenceIdForParameters = $definitionReferenceIdForParameters.Replace("'", "\'")
-          }
+            # If definitionReferenceId or definitionReferenceIdForParameters contains apostrophes, replace that apostrophe with a backslash and an apostrohphe for Bicep string escaping
+            if ($definitionReferenceId.Contains("'")) {
+              $definitionReferenceId = $definitionReferenceId.Replace("'", "\'")
+            }
 
-          # If definitionReferenceId contains, then wrap in definitionReferenceId value in [] to comply with bicep formatting
-          if ($definitionReferenceIdForParameters.Contains("-") -or $definitionReferenceIdForParameters.Contains(" ") -or $definitionReferenceIdForParameters.Contains("\'")) {
-            $definitionReferenceIdForParameters = "['$definitionReferenceIdForParameters']"
+            if ($definitionReferenceIdForParameters.Contains("'")) {
+              $definitionReferenceIdForParameters = $definitionReferenceIdForParameters.Replace("'", "\'")
+            }
 
-            # Add nested array of objects to each Policy Set/Initiative Definition in the Bicep variable, without the '.' before the definitionReferenceId to make it an accessor
-            Add-Content -Path "$rootPath/$definitionsSetLongPath/$defintionsSetTxtFileName" -Encoding "utf8" -Value "`t`t`t{`r`n`t`t`t`tdefinitionReferenceId: '$definitionReferenceId'`r`n`t`t`t`tdefinitionId: '$definitionId'`r`n`t`t`t`tdefinitionParameters: $policySetDefParamVarCreation$definitionReferenceIdForParameters.parameters`r`n`t`t`t`tdefinitionGroups: [$groups]`r`n`t`t`t}"
+            # If definitionReferenceId contains, then wrap in definitionReferenceId value in [] to comply with bicep formatting
+            if ($definitionReferenceIdForParameters.Contains("-") -or $definitionReferenceIdForParameters.Contains(" ") -or $definitionReferenceIdForParameters.Contains("\'")) {
+              $definitionReferenceIdForParameters = "['$definitionReferenceIdForParameters']"
+
+              # Add nested array of objects to each Policy Set/Initiative Definition in the Bicep variable, without the '.' before the definitionReferenceId to make it an accessor
+              Add-Content -Path "$rootPath/$definitionsSetLongPath/$defintionsSetTxtFileName" -Encoding "utf8" -Value "`t`t`t{`r`n`t`t`t`tdefinitionReferenceId: '$definitionReferenceId'`r`n`t`t`t`tdefinitionId: '$definitionId'`r`n`t`t`t`tdefinitionParameters: $policySetDefParamVarCreation$definitionReferenceIdForParameters.parameters`r`n`t`t`t`tdefinitionGroups: [$groups]`r`n`t`t`t}"
+            }
+            else {
+              # Add nested array of objects to each Policy Set/Initiative Definition in the Bicep variable
+              Add-Content -Path "$rootPath/$definitionsSetLongPath/$defintionsSetTxtFileName" -Encoding "utf8" -Value "`t`t`t{`r`n`t`t`t`tdefinitionReferenceId: '$definitionReferenceId'`r`n`t`t`t`tdefinitionId: '$definitionId'`r`n`t`t`t`tdefinitionParameters: $policySetDefParamVarCreation.$definitionReferenceIdForParameters.parameters`r`n`t`t`t`tdefinitionGroups: [$groups]`r`n`t`t`t}"
+            }
           }
           else {
-            # Add nested array of objects to each Policy Set/Initiative Definition in the Bicep variable
-            Add-Content -Path "$rootPath/$definitionsSetLongPath/$defintionsSetTxtFileName" -Encoding "utf8" -Value "`t`t`t{`r`n`t`t`t`tdefinitionReferenceId: '$definitionReferenceId'`r`n`t`t`t`tdefinitionId: '$definitionId'`r`n`t`t`t`tdefinitionParameters: $policySetDefParamVarCreation.$definitionReferenceIdForParameters.parameters`r`n`t`t`t`tdefinitionGroups: [$groups]`r`n`t`t`t}"
+            Write-Information "==> Skipping '$definitionReferenceId' as it is in the excluded list" -InformationAction Continue
           }
         }
       }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Add ability to exclude policy set/initiative child definitions for China policies via new `$excludedPolicySetChildDefinitionsReferenceIds` parameter input in `Invoke-PolicyToBicep-China.ps1` module and associated functions. Also added known default values to exclude from start based on definition reference IDs

## This PR fixes/adds/changes/removes

1. Helps to work towards closure of #365

### Breaking Changes

None

## Testing Evidence

![image](https://user-images.githubusercontent.com/41163455/200304088-f2b4132d-aaaf-4371-a5b9-b43098410aac.png)


## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [x] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [x] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
