### PR TITLE
removed duplicated settings

### DIFF
--- a/infra-as-code/bicep/modules/policy/definitions/lib/policy_definitions/policy_definition_es_Deploy-Diagnostics-Website.json
+++ b/infra-as-code/bicep/modules/policy/definitions/lib/policy_definitions/policy_definition_es_Deploy-Diagnostics-Website.json
@@ -171,10 +171,6 @@
                           "enabled": "[parameters('logsEnabled')]"
                         },
                         {
-                          "category": "AppServiceHTTPLogs",
-                          "enabled": "[parameters('logsEnabled')]"
-                        },
-                        {
                           "category": "AppServiceAppLogs",
                           "enabled": "[parameters('logsEnabled')]"
                         },


### PR DESCRIPTION

# Overview/Summary

removes duplicate lines from policy definition 

## This PR fixes/adds/changes/removes

Lines 173-176 are removed

                        {
                          "category": "AppServiceHTTPLogs",
                          "enabled": "[parameters('logsEnabled')]"
                        },

from file 
infra-as-code/bicep/modules/policy/definitions/lib/policy_definitions/policy_definition_es_Deploy-Diagnostics-Website.json


### Breaking Changes

no breaking changes

## Testing Evidence

screenshots attached
![after_change](https://user-images.githubusercontent.com/5805065/201314860-4d311aca-7038-4e4e-8147-cec9f2292130.jpg)
![before_change](https://user-images.githubusercontent.com/5805065/201314867-a8213111-b34d-4f71-b0fc-2865e85d790d.jpg)

## As part of this Pull Request I have


- [x ]  Associated with https://dev.azure.com/CSUSolEng/Azure%20Landing%20Zones/_workitems/edit/25022
- [x ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ x] Performed testing and provided evidence.

