### PR TITLE
Update containerRegistry API version

### DIFF
--- a/infra-as-code/bicep/CRML/containerRegistry/containerRegistry.bicep
+++ b/infra-as-code/bicep/CRML/containerRegistry/containerRegistry.bicep
@@ -26,7 +26,7 @@ param parAcrSku string = 'Basic'
 @sys.description('Tags to be applied to resource when deployed.  Default: None')
 param parTags object ={}
 
-resource resAzureContainerRegistry 'Microsoft.ContainerRegistry/registries@2022-02-01-preview' = {
+resource resAzureContainerRegistry 'Microsoft.ContainerRegistry/registries@2022-12-01' = {
   name: parAcrName
   tags: parTags
   location: parLocation

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
@@ -488,7 +488,7 @@ module modGatewayPublicIp '../publicIp/publicIp.bicep' = [for (gateway, i) in va
 }]
 
 //Minumum subnet size is /27 supporting documentation https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub
-resource resGateway 'Microsoft.Network/virtualNetworkGateways@2021-02-01' = [for (gateway, i) in varGwConfig: if ((gateway.name != 'noconfigVpn') && (gateway.name != 'noconfigEr')) {
+resource resGateway 'Microsoft.Network/virtualNetworkGateways@2022-07-01' = [for (gateway, i) in varGwConfig: if ((gateway.name != 'noconfigVpn') && (gateway.name != 'noconfigEr')) {
   name: gateway.name
   location: parLocation
   tags: parTags


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
Addendum for #247

Updated ACR API version from preview to the latest stable as it was giving a deploy error. 

```
/home/vsts/work/1/s/infra-as-code/bicep/CRML/containerRegistry/containerRegistry.bicep(29,76) : Error use-recent-api-versions: Use more recent API version for 'Microsoft.ContainerRegistry/registries'. '2022-02-01-preview' is a preview version and there is a more recent non-preview version available. Acceptable versions: 2023-01-01-preview, 2022-12-01, 2021-09-01 [https://aka.ms/bicep/linter/use-recent-api-versions]
/home/vsts/work/1/s/infra-as-code/bicep/orchestration/governanceacr/governanceacr.bicep(34,34) : Error BCP104: The referenced module has errors.
##[error]Script failed with exit code: 1
```

## This PR fixes/adds/changes/removes

1. containerRegistry API version

## Testing Evidence

![image](https://user-images.githubusercontent.com/5115577/216317457-e58976f7-bf25-432e-8367-a5941c3116f6.png)

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [X] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [X] Performed testing and provided evidence.