### PR TITLE
CaseSensitiveDeploymentParameterNamesFound

### DIFF
--- a/infra-as-code/bicep/orchestration/hubPeeredSpoke/parameters/hubPeeredSpoke.parameters.all.json
+++ b/infra-as-code/bicep/orchestration/hubPeeredSpoke/parameters/hubPeeredSpoke.parameters.all.json
@@ -31,8 +31,8 @@
       },
       "parDisableBgpRoutePropagation": {
         "value": false
-      },      
-      "parSpoketoHubRouteTableName": {
+      },
+      "parSpokeToHubRouteTableName": {
         "value": "rtb-spoke-to-hub"
       },
       "parHubVirtualNetworkId": {
@@ -41,7 +41,7 @@
       "parAllowSpokeForwardedTraffic": {
         "value": false
       },
-      "parAllowHubVPNGatewayTransit": {
+      "parAllowHubVpnGatewayTransit": {
         "value": true
       },
       "parTags": {

--- a/infra-as-code/bicep/orchestration/hubPeeredSpoke/parameters/hubPeeredSpoke.vwan.parameters.all.json
+++ b/infra-as-code/bicep/orchestration/hubPeeredSpoke/parameters/hubPeeredSpoke.vwan.parameters.all.json
@@ -31,8 +31,8 @@
       },
       "parDisableBgpRoutePropagation": {
         "value": false
-      },      
-      "parSpoketoHubRouteTableName": {
+      },
+      "parSpokeToHubRouteTableName": {
         "value": "rtb-spoke-to-hub"
       },
       "parHubVirtualNetworkId": {
@@ -41,7 +41,7 @@
       "parAllowSpokeForwardedTraffic": {
         "value": false
       },
-      "parAllowHubVPNGatewayTransit": {
+      "parAllowHubVpnGatewayTransit": {
         "value": true
       },
       "parTags": {


### PR DESCRIPTION
The deployment parameters are using case sensitive names. The error parameter name(s): parAllowHubVpnGatewayTransit,parSpokeToHubRouteTableName

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixed parameter cases in Orchestration - hubPeeredSpoke which was causing CaseSensitiveDeploymentParameterNamesFound error

## This PR fixes/adds/changes/removes

1. Corrected case of parSpokeToHubRouteTableName in hubPeeredSpoke.parameters.all.json 
2. Corrected case of parAllowHubVpnGatewayTransit in hubPeeredSpoke.parameters.all.json 
3. Corrected case of parSpokeToHubRouteTableName in hubPeeredSpoke.vwan.parameters.all.json
4. Corrected case of parAllowHubVpnGatewayTransit in hubPeeredSpoke.vwan.parameters.all.json

### Breaking Changes

1. CaseSensitiveDeploymentParameterNamesFound - The deployment parameters are using case sensitive names. The error parameter name(s): parSpokeToHubRouteTableName,parAllowHubVpnGatewayTransit

## Testing Evidence
Error:  
![image](https://user-images.githubusercontent.com/5359639/220747613-e031be38-ed98-4248-ad57-4600b221d21f.png)

Tested:  
![image](https://user-images.githubusercontent.com/5359639/220748275-86ac2d33-3f42-492e-a2f1-5c0ba472f871.png)


## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
