### PR TITLE
Update DeploymentFlow.md

### DIFF
--- a/docs/wiki/DeploymentFlow.md
+++ b/docs/wiki/DeploymentFlow.md
@@ -84,7 +84,7 @@ The current available orchestration modules are listed below:
 
 When first working with Management Groups, the Azure AD Global Administrator must assign the User Access Administrator role to themselves at the `/` scope first before being able to further delegate. See [Elevate access to manage all Azure subscriptions and management groups](https://learn.microsoft.com/azure/role-based-access-control/elevate-access-global-admin) documentation for further information.
 
-In addition, the identity that wants to create a Tenant scope deployment must have the _Owner_ role assigned to the `/` root management group. Whether this is your Global Administrator account or a Service Principal. See [Required access for Tenant deployments on Azure Docs](https://learn.microsoft.com/azure/azure-resource-manager/templates/deploy-to-tenant?tabs=azure-powershell#required-access).
+In addition, the identity that wants to create a Tenant scope deployment must have the _Owner_ role assigned to the `/` root management group. Whether this is your user account (even if a Global Administrator) or a Service Principal. See [Required access for Tenant deployments on Azure Docs](https://learn.microsoft.com/azure/azure-resource-manager/templates/deploy-to-tenant?tabs=azure-powershell#required-access).
 
 ### Service Principal Account
 

--- a/docs/wiki/DeploymentFlow.md
+++ b/docs/wiki/DeploymentFlow.md
@@ -84,7 +84,7 @@ The current available orchestration modules are listed below:
 
 When first working with Management Groups, the Azure AD Global Administrator must assign the User Access Administrator role to themselves at the `/` scope first before being able to further delegate. See [Elevate access to manage all Azure subscriptions and management groups](https://learn.microsoft.com/azure/role-based-access-control/elevate-access-global-admin) documentation for further information.
 
-In addition, the identity that wants to create a Tenant scope deployment must have the _Owner_ role assigned to the `/` root management group. Whether this is your user account (even if a Global Administrator) or a Service Principal. See [Required access for Tenant deployments on Azure Docs](https://learn.microsoft.com/azure/azure-resource-manager/templates/deploy-to-tenant?tabs=azure-powershell#required-access).
+In addition, the identity that wants to create a Tenant scope deployment must have the *Owner* role assigned to the `/` root management group. Whether this is your user account (even if a Global Administrator) or a Service Principal. See [Required access for Tenant deployments on Azure Docs](https://learn.microsoft.com/azure/azure-resource-manager/templates/deploy-to-tenant?tabs=azure-powershell#required-access).
 
 ### Service Principal Account
 

--- a/docs/wiki/DeploymentFlow.md
+++ b/docs/wiki/DeploymentFlow.md
@@ -82,7 +82,9 @@ The current available orchestration modules are listed below:
 
 ## Deployment Identity
 
-> When first working with Management Groups, the Azure AD Global Administrator must assign the User Access Administrator role to themselves at the `/` scope first before being able to further delegate. See [Elevate access to manage all Azure subscriptions and management groups](https://learn.microsoft.com/azure/role-based-access-control/elevate-access-global-admin) documentation for further information.
+When first working with Management Groups, the Azure AD Global Administrator must assign the User Access Administrator role to themselves at the `/` scope first before being able to further delegate. See [Elevate access to manage all Azure subscriptions and management groups](https://learn.microsoft.com/azure/role-based-access-control/elevate-access-global-admin) documentation for further information.
+
+In addition, the identity that wants to create a Tenant scope deployment must have the _Owner_ role assigned to the `/` root management group. Whether this is your Global Administrator account or a Service Principal. See [Required access for Tenant deployments on Azure Docs](https://learn.microsoft.com/azure/azure-resource-manager/templates/deploy-to-tenant?tabs=azure-powershell#required-access).
 
 ### Service Principal Account
 
@@ -92,8 +94,6 @@ A service principal account is required to automate through Azure DevOps or GitH
 - **RBAC Assignment**
   - Scope:  `/` (Root Management Group)
   - Role Assignment:  `Owner`
-
-> See [step-by-step instructions on Azure Docs](https://learn.microsoft.com/azure/azure-resource-manager/templates/deploy-to-tenant?tabs=azure-powershell#required-access) to configure the role assignment at `/` root management group.
 
 ### Configure Service Principal Account in Azure DevOps or GitHub
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

As requested in this [issue](https://github.com/Azure/ALZ-Bicep/issues/458), i propose a change.

The information, that an identity needs to be _Owner_ of the `/` root management group for Tenant scope deployments, is important for every type of identity. Not only Service Principals.

## This PR fixes/adds/changes/removes
Move the information on how to grant root management group owner from _Service Principal_ to _Deployment Identity_.