### PR TITLE
Update RSG API version & workflow to only run on this repo

### DIFF
--- a/.github/workflows/scheduled-bicep-build.yml
+++ b/.github/workflows/scheduled-bicep-build.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   bicep_unit_tests:
     name: Bicep Build & Lint All Modules
+    if: github.repository == 'Azure/ALZ-Bicep'
     runs-on: ubuntu-latest
 
     steps:

--- a/infra-as-code/bicep/modules/resourceGroup/resourceGroup.bicep
+++ b/infra-as-code/bicep/modules/resourceGroup/resourceGroup.bicep
@@ -18,7 +18,7 @@ param parTelemetryOptOut bool = false
 // Customer Usage Attribution Id
 var varCuaid = 'b6718c54-b49e-4748-a466-88e3d7c789c8'
 
-resource resResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   location: parLocation
   name: parResourceGroupName
   tags: parTags


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Update RSG API version & workflow to only run on this repo

## This PR fixes/adds/changes/removes

1. Fixes #485 

### Breaking Changes

None

## Testing Evidence

Linting and automated tests will suffice

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [x] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [x] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
