### PR TITLE
hubNetwork: Dynamic prefix and suffix for Public IPs

### DIFF
--- a/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
+++ b/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
@@ -100,15 +100,13 @@ Public IP Address SKU.
 
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
 
-Public IP Address Prefix.
-
-- Default value: ` `
+Optional Prefix for Public IPs. Include a succedent dash if required. Example: prefix-
 
 ### parPublicIpSuffix
 
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
 
-Public IP Address Suffix.
+Optional Suffix for Public IPs. Include a preceding dash if required. Example: -suffix
 
 - Default value: `-PublicIP`
 
@@ -366,6 +364,12 @@ outHubVirtualNetworkId | string |
         },
         "parPublicIpSku": {
             "value": "Standard"
+        },
+        "parPublicIpPrefix": {
+            "value": ""
+        },
+        "parPublicIpSuffix": {
+            "value": "-PublicIP"
         },
         "parAzBastionEnabled": {
             "value": true

--- a/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
+++ b/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
@@ -13,6 +13,8 @@ parHubNetworkAddressPrefix | No       | The IP address range for all virtual net
 parSubnets     | No       | The name and IP address range for each subnet in the virtual networks.
 parDnsServerIps | No       | Array of DNS Server IP addresses for VNet.
 parPublicIpSku | No       | Public IP Address SKU.
+parPublicIpPrefix | No       | Optional Prefix for Public IPs. Include a succedent dash if required. Example: prefix-
+parPublicIpSuffix | No       | Optional Suffix for Public IPs. Include a preceding dash if required. Example: -suffix
 parAzBastionEnabled | No       | Switch to enable/disable Azure Bastion deployment. Default: true
 parAzBastionName | No       | Name Associated with Bastion Service.
 parAzBastionSku | No       | Azure Bastion SKU or Tier to deploy.  Currently two options exist Basic and Standard.
@@ -93,6 +95,22 @@ Public IP Address SKU.
 - Default value: `Standard`
 
 - Allowed values: `Basic`, `Standard`
+
+### parPublicIpPrefix
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Public IP Address Prefix.
+
+- Default value: ` `
+
+### parPublicIpSuffix
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Public IP Address Suffix.
+
+- Default value: `-PublicIP`
 
 ### parAzBastionEnabled
 

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
@@ -39,6 +39,12 @@ param parDnsServerIps array = []
 ])
 param parPublicIpSku string = 'Standard'
 
+@sys.description('Optional Prefix for Public IPs. Include a succedent dash if required. Example: prefix-')
+param parPublicIpPrefix string = ''
+
+@sys.description('Optional Suffix for Public IPs. Include a preceding dash if required. Example: -suffix')
+param parPublicIpSuffix string = '-PublicIP'
+
 @sys.description('Switch to enable/disable Azure Bastion deployment. Default: true')
 param parAzBastionEnabled bool = true
 
@@ -295,7 +301,7 @@ module modBastionPublicIp '../publicIp/publicIp.bicep' = if (parAzBastionEnabled
   name: 'deploy-Bastion-Public-IP'
   params: {
     parLocation: parLocation
-    parPublicIpName: '${parAzBastionName}-PublicIp'
+    parPublicIpName: '${parPublicIpPrefix}${parAzBastionName}${parPublicIpSuffix}'
     parPublicIpSku: {
       name: parPublicIpSku
     }
@@ -500,7 +506,7 @@ module modGatewayPublicIp '../publicIp/publicIp.bicep' = [for (gateway, i) in va
   params: {
     parLocation: parLocation
     parAvailabilityZones: gateway.gatewayType == 'ExpressRoute' ? parAzErGatewayAvailabilityZones : gateway.gatewayType == 'Vpn' ? parAzVpnGatewayAvailabilityZones : []
-    parPublicIpName: '${gateway.name}-PublicIp'
+    parPublicIpName: '${parPublicIpPrefix}${gateway.name}${parPublicIpSuffix}'
     parPublicIpProperties: {
       publicIpAddressVersion: 'IPv4'
       publicIpAllocationMethod: 'Static'
@@ -558,7 +564,7 @@ module modAzureFirewallPublicIp '../publicIp/publicIp.bicep' = if (parAzFirewall
   params: {
     parLocation: parLocation
     parAvailabilityZones: parAzFirewallAvailabilityZones
-    parPublicIpName: '${parAzFirewallName}-PublicIp'
+    parPublicIpName: '${parPublicIpPrefix}${parAzFirewallName}${parPublicIpSuffix}'
     parPublicIpProperties: {
       publicIpAddressVersion: 'IPv4'
       publicIpAllocationMethod: 'Static'

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.all.json
@@ -36,6 +36,12 @@
     "parPublicIpSku": {
       "value": "Standard"
     },
+    "parPublicIpPrefix": {
+      "value": ""
+    },
+    "parPublicIpSuffix": {
+      "value": "-PublicIP"
+    },
     "parAzBastionEnabled": {
       "value": true
     },

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.all.json
@@ -36,6 +36,12 @@
     "parPublicIpSku": {
       "value": "Standard"
     },
+    "parPublicIpPrefix": {
+      "value": ""
+    },
+    "parPublicIpSuffix": {
+      "value": "-PublicIP"
+    },
     "parAzBastionEnabled": {
       "value": true
     },


### PR DESCRIPTION
# Overview/Summary

Public IPs created in the hubNetwork module has the suffic '-PublicIP' hardcoded in the bicepfile. This PR adds support to change this suffix and/or add a prefix, such as 'pip-serviceName'

## This PR fixes/adds/changes/removes


1. adds parameter parPublicIpPrefix and parPublicIpSuffix in hubNetworking module
2. updated the generated docs for the hubNetworking module

### Breaking Changes

No breaking changes

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
