### PR TITLE
ADO 27172 - Add Zero Trust Networking Telemetry - Phase 1

### DIFF
--- a/docs/wiki/CustomerUsage.md
+++ b/docs/wiki/CustomerUsage.md
@@ -29,27 +29,50 @@ module modCustomerUsageAttribution '../../CRML/customerUsageAttribution/cuaIdTen
 
 The following are the unique ID's (also known as PIDs) used in each of the modules:
 
-| Module Name                     | PID                                  |
-| ------------------------------- | ------------------------------------ |
-| customRoleDefinitions           | 032d0904-3d50-45ef-a6c1-baa9d82e23ff |
-| getManagementGroupName          | cff0ca56-5d8c-4594-bf79-5c046809b017 |
-| hubNetworking                   | 2686e846-5fdc-4d4f-b533-16dcb09d6e6c |
-| logging                         | f8087c67-cc41-46b2-994d-66e4b661860d |
-| managementGroups                | 9b7965a0-d77c-41d6-85ef-ec3dfea4845b |
-| mgDiagSettings                  | 5d17f1c2-f17b-4426-9712-0cd2652c4435 |
-| policy-definitions              | 2b136786-9881-412e-84ba-f4c2822e1ac9 |
-| policy-assignments              | 78001e36-9738-429c-a343-45cc84e8a527 |
-| alzDefaultPolicyAssignments     | 98cef979-5a6b-403b-83c7-10c8f04ac9a2 |
-| publicIp                        | 3f85b84c-6bad-4c42-86bf-11c233241c22 |
-| resourceGroup                   | b6718c54-b49e-4748-a466-88e3d7c789c8 |
-| roleAssignments                 | 59c2ac61-cd36-413b-b999-86a3e0d958fb |
-| spokeNetworking                 | 0c428583-f2a1-4448-975c-2d6262fd193a |
-| subscriptionPlacement           | 3dfa9e81-f0cf-4b25-858e-167937fd380b |
-| virtualNetworkPeer              | ab8e3b12-b0fa-40aa-8630-e3f7699e2142 |
-| vwanConnectivity                | 7f94f23b-7a59-4a5c-9a8d-2a253a566f61 |
-| vnetPeeringVwan                 | 7b5e6db2-1e8c-4b01-8eee-e1830073a63d |
-| privateDnsZones                 | 981733dd-3195-4fda-a4ee-605ab959edb6 |
-| hubSpoke - Orchestration        | 50ad3b1a-f72c-4de4-8293-8a6399991beb |
-| hubPeeredSpoke - Orchestration  | 8ea6f19a-d698-4c00-9afb-5c92d4766fd2 |
-| SubPlacementAll - Orchestration | bb800623-86ff-4ab4-8901-93c2b70967ae |
+| Module Name                       | PID                                  |
+| --------------------------------- | ------------------------------------ |
+| customRoleDefinitions             | 032d0904-3d50-45ef-a6c1-baa9d82e23ff |
+| getManagementGroupName            | cff0ca56-5d8c-4594-bf79-5c046809b017 |
+| hubNetworking                     | 2686e846-5fdc-4d4f-b533-16dcb09d6e6c |
+| logging                           | f8087c67-cc41-46b2-994d-66e4b661860d |
+| managementGroups                  | 9b7965a0-d77c-41d6-85ef-ec3dfea4845b |
+| mgDiagSettings                    | 5d17f1c2-f17b-4426-9712-0cd2652c4435 |
+| policy-definitions                | 2b136786-9881-412e-84ba-f4c2822e1ac9 |
+| policy-assignments                | 78001e36-9738-429c-a343-45cc84e8a527 |
+| alzDefaultPolicyAssignments       | 98cef979-5a6b-403b-83c7-10c8f04ac9a2 |
+| publicIp                          | 3f85b84c-6bad-4c42-86bf-11c233241c22 |
+| resourceGroup                     | b6718c54-b49e-4748-a466-88e3d7c789c8 |
+| roleAssignments                   | 59c2ac61-cd36-413b-b999-86a3e0d958fb |
+| spokeNetworking                   | 0c428583-f2a1-4448-975c-2d6262fd193a |
+| subscriptionPlacement             | 3dfa9e81-f0cf-4b25-858e-167937fd380b |
+| virtualNetworkPeer                | ab8e3b12-b0fa-40aa-8630-e3f7699e2142 |
+| vwanConnectivity                  | 7f94f23b-7a59-4a5c-9a8d-2a253a566f61 |
+| vnetPeeringVwan                   | 7b5e6db2-1e8c-4b01-8eee-e1830073a63d |
+| privateDnsZones                   | 981733dd-3195-4fda-a4ee-605ab959edb6 |
+| hubSpoke - Orchestration          | 50ad3b1a-f72c-4de4-8293-8a6399991beb |
+| hubPeeredSpoke - Orchestration    | 8ea6f19a-d698-4c00-9afb-5c92d4766fd2 |
+| SubPlacementAll - Orchestration   | bb800623-86ff-4ab4-8901-93c2b70967ae |
 | mgDiagSettingsAll - Orchestration | f49c8dfb-c0ce-4ee0-b316-5e4844474dd0 |
+
+### Zero Trust Networking Telemetry
+
+In an aligned effort with the Azure Networking Product Group, we have created an additional telemetry collection point to help us see customer choosing to adopt Zero Trust Networking best practices from ALZ.
+
+> There will be multiple phases for Zero Trust Networking in ALZ that will mean additional telemetry collection points being added over time. This will only be captured when you run a portal deployment and select to leave telemetry collection enabled.
+
+#### ALZ Bicep - Zero Trust Networking - Phase 1 | Definition
+
+The following conditions and their values must be met for the telemetry point to be triggered for collection:
+
+1. Enable DDOS Protection is `true` in Hub and Spoke or Virtual WAN topologies
+2. Deploy Azure Firewall is `True` in Hub and Spoke or Virtual WAN topologies
+3. Azure Firewall Tier is `Premium` in Hub and Spoke or Virtual WAN topologies
+4. Ensure subnets are associated with NSG is `true` in both Landing Zones & Identity Management Groups
+5. Ensure secure connections to storage accounts (https) is `true` in the Landing Zones Management Group
+
+#### ALZ Bicep - Zero Trust Networking - Phase 1 | PID Mapping
+
+| Telemetry Collection Point | PID                                  |
+| -------------------------- | ------------------------------------ |
+| Definition points 1, 2 & 3 | 3ab23b1e-c5c5-42d4-b163-1402384ba2db |
+| Definition points 4 & 5    | 4eaba1fc-d30a-4e63-a57f-9e6c3d86a318 |

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
@@ -263,16 +263,20 @@ var varGwConfig = [
   varErGwConfig
 ]
 
-// Customer Usage Attribution Id
+// Customer Usage Attribution Id Telemetry
 var varCuaid = '2686e846-5fdc-4d4f-b533-16dcb09d6e6c'
 
+// ZTN Telemetry
+var varZtnP1CuaId = '3ab23b1e-c5c5-42d4-b163-1402384ba2db'
+var varZtnP1Trigger = (parDdosEnabled && parAzFirewallEnabled && (parAzFirewallTier == 'Premium')) ? true : false
+
+//DDos Protection plan will only be enabled if parDdosEnabled is true.
 resource resDdosProtectionPlan 'Microsoft.Network/ddosProtectionPlans@2021-08-01' = if (parDdosEnabled) {
   name: parDdosPlanName
   location: parLocation
   tags: parTags
 }
 
-//DDos Protection plan will only be enabled if parDdosEnabled is true.
 resource resHubVnet 'Microsoft.Network/virtualNetworks@2021-08-01' = {
   dependsOn: [
     resBastionNsg
@@ -654,10 +658,16 @@ module modPrivateDnsZones '../privateDnsZones/privateDnsZones.bicep' = if (parPr
   }
 }
 
-// Optional Deployment for Customer Usage Attribution
+// Optional Deployments for Customer Usage Attribution
 module modCustomerUsageAttribution '../../CRML/customerUsageAttribution/cuaIdResourceGroup.bicep' = if (!parTelemetryOptOut) {
   #disable-next-line no-loc-expr-outside-params //Only to ensure telemetry data is stored in same location as deployment. See https://github.com/Azure/ALZ-Bicep/wiki/FAQ#why-are-some-linter-rules-disabled-via-the-disable-next-line-bicep-function for more information
   name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
+}
+
+module modCustomerUsageAttributionZtnP1 '../../CRML/customerUsageAttribution/cuaIdResourceGroup.bicep' = if (!parTelemetryOptOut && varZtnP1Trigger) {
+  #disable-next-line no-loc-expr-outside-params //Only to ensure telemetry data is stored in same location as deployment. See https://github.com/Azure/ALZ-Bicep/wiki/FAQ#why-are-some-linter-rules-disabled-via-the-disable-next-line-bicep-function for more information
+  name: 'pid-${varZtnP1CuaId}-${uniqueString(resourceGroup().location)}'
   params: {}
 }
 

--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
@@ -55,8 +55,12 @@ var varLogAnalyticsWorkspaceResourceGroupName = split(parLogAnalyticsWorkspaceRe
 
 var varLogAnalyticsWorkspaceSubscription = split(parLogAnalyticsWorkspaceResourceId, '/')[2]
 
-// Customer Usage Attribution Id
+// Customer Usage Attribution Id Telemetry
 var varCuaid = '98cef979-5a6b-403b-83c7-10c8f04ac9a2'
+
+// ZTN Telemetry
+var varZtnP1CuaId = '4eaba1fc-d30a-4e63-a57f-9e6c3d86a318'
+var varZtnP1Trigger = ((!contains(parExcludedPolicyAssignments, varPolicyAssignmentDenySubnetWithoutNsg.libDefinition.name)) && (!contains(parExcludedPolicyAssignments, varPolicyAssignmentDenyStoragehttp.libDefinition.name))) ? true : false
 
 // **Variables**
 // Orchestration Module Variables
@@ -388,10 +392,16 @@ var varPrivateDnsZonesFinalResourceIds = {
 // **Scope**
 targetScope = 'managementGroup'
 
-// Optional Deployment for Customer Usage Attribution
+// Optional Deployments for Customer Usage Attribution
 module modCustomerUsageAttribution '../../../../CRML/customerUsageAttribution/cuaIdManagementGroup.bicep' = if (!parTelemetryOptOut) {
   #disable-next-line no-loc-expr-outside-params //Only to ensure telemetry data is stored in same location as deployment. See https://github.com/Azure/ALZ-Bicep/wiki/FAQ#why-are-some-linter-rules-disabled-via-the-disable-next-line-bicep-function for more information
   name: 'pid-${varCuaid}-${uniqueString(deployment().location)}'
+  params: {}
+}
+
+module modCustomerUsageAttributionZtnP1 '../../../../CRML/customerUsageAttribution/cuaIdManagementGroup.bicep' = if (!parTelemetryOptOut && varZtnP1Trigger) {
+  #disable-next-line no-loc-expr-outside-params //Only to ensure telemetry data is stored in same location as deployment. See https://github.com/Azure/ALZ-Bicep/wiki/FAQ#why-are-some-linter-rules-disabled-via-the-disable-next-line-bicep-function for more information
+  name: 'pid-${varZtnP1CuaId}-${uniqueString(deployment().location)}'
   params: {}
 }
 
@@ -665,7 +675,6 @@ module modPolicyAssignmentIntRootDenyClassicRes '../../../policy/assignments/pol
     parTelemetryOptOut: parTelemetryOptOut
   }
 }
-
 
 // Modules - Policy Assignments - Connectivity Management Group
 // Module - Policy Assignment - Enable-DDoS-VNET

--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -165,8 +165,12 @@ param parTags object = {}
 @sys.description('Set Parameter to true to Opt-out of deployment telemetry')
 param parTelemetryOptOut bool = false
 
-// Customer Usage Attribution Id
+// Customer Usage Attribution Id Telemetry
 var varCuaid = '7f94f23b-7a59-4a5c-9a8d-2a253a566f61'
+
+// ZTN Telemetry
+var varZtnP1CuaId = '3ab23b1e-c5c5-42d4-b163-1402384ba2db'
+var varZtnP1Trigger = (parDdosEnabled && !(contains(map(parVirtualWanHubs, hub => hub.parAzFirewallEnabled), false)) && (parAzFirewallTier == 'Premium')) ? true : false
 
 // Virtual WAN resource
 resource resVwan 'Microsoft.Network/virtualWans@2022-01-01' = {
@@ -312,9 +316,14 @@ module modPrivateDnsZones '../privateDnsZones/privateDnsZones.bicep' = if (parPr
 }
 
 
-// Optional Deployment for Customer Usage Attribution
+// Optional Deployments for Customer Usage Attribution
 module modCustomerUsageAttribution '../../CRML/customerUsageAttribution/cuaIdResourceGroup.bicep' = if (!parTelemetryOptOut) {
   name: 'pid-${varCuaid}-${uniqueString(parLocation)}'
+  params: {}
+}
+
+module modCustomerUsageAttributionZtnP1 '../../CRML/customerUsageAttribution/cuaIdResourceGroup.bicep' = if (!parTelemetryOptOut && varZtnP1Trigger) {
+  name: 'pid-${varZtnP1CuaId}-${uniqueString(parLocation)}'
   params: {}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Adds additional telemetry deployments if certain resources are deployed in the modules that indicate customers is adopting Zero Trust Networking principles. It also still honours the disabling of telemetry via the parameter `parTelemetryOptOut`.

## This PR fixes/adds/changes/removes

1. [AB#27172](https://dev.azure.com/CSUSolEng/2a9d5a5a-8998-4ad0-81c8-ef3045e4da97/_workitems/edit/27172)

### Breaking Changes

None

## Testing Evidence

Tested complex ternary inputs with the below code:
```bicep
targetScope = 'tenant'

param parVirtualWanHubs array = [ {
    parVpnGatewayEnabled: true
    parExpressRouteGatewayEnabled: true
    parAzFirewallEnabled: true
    parVirtualHubAddressPrefix: '10.100.0.0/23'
    parHubLocation: 'eastus'
    parHubRoutingPreference: 'ExpressRoute' //allowed values are 'ASN','VpnGateway','ExpressRoute'.
    parVirtualRouterAutoScaleConfiguration: 2 //minimum capacity should be between 2 to 50
  }
  {
    parVpnGatewayEnabled: true
    parExpressRouteGatewayEnabled: true
    parAzFirewallEnabled: false
    parVirtualHubAddressPrefix: '10.200.0.0/23'
    parHubLocation: 'uksouth'
    parHubRoutingPreference: 'ExpressRoute' //allowed values are 'ASN','VpnGateway','ExpressRoute'.
    parVirtualRouterAutoScaleConfiguration: 2 //minimum capacity should be between 2 to 50
  }
  {
    parVpnGatewayEnabled: true
    parExpressRouteGatewayEnabled: true
    parAzFirewallEnabled: true
    parVirtualHubAddressPrefix: '10.1.0.0/23'
    parHubLocation: 'uksouth'
    parHubRoutingPreference: 'ExpressRoute' //allowed values are 'ASN','VpnGateway','ExpressRoute'.
    parVirtualRouterAutoScaleConfiguration: 2 //minimum capacity should be between 2 to 50
  }
]

var varCombined = !(contains(map(parVirtualWanHubs, hub => hub.parAzFirewallEnabled), false)) ? true : false

output outFinal bool = varCombined
``` 

And outputs correct `bool` value when all `parAzFirewallEnabled` property values are `true`

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [x] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
