### PR TITLE
remove unused duplicate `asn` property

### DIFF
--- a/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
+++ b/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
@@ -273,7 +273,7 @@ Configuration for VPN virtual network gateway to be deployed. If a VPN virtual n
   "value": {}
 }
 
-- Default value: `@{name=[format('{0}-Vpn-Gateway', parameters('parCompanyPrefix'))]; gatewayType=Vpn; sku=VpnGw1; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; asn=65515; bgpPeeringAddress=; bgpsettings=}`
+- Default value: `@{name=[format('{0}-Vpn-Gateway', parameters('parCompanyPrefix'))]; gatewayType=Vpn; sku=VpnGw1; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpsettings=}`
 
 ### parExpressRouteGatewayConfig
 
@@ -284,7 +284,7 @@ Configuration for ExpressRoute virtual network gateway to be deployed. If a Expr
   "value": {}
 }
 
-- Default value: `@{name=[format('{0}-ExpressRoute-Gateway', parameters('parCompanyPrefix'))]; gatewayType=ExpressRoute; sku=ErGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=None; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; asn=65515; bgpPeeringAddress=; bgpsettings=}`
+- Default value: `@{name=[format('{0}-ExpressRoute-Gateway', parameters('parCompanyPrefix'))]; gatewayType=ExpressRoute; sku=ErGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=None; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpsettings=}`
 
 ### parTags
 
@@ -507,7 +507,6 @@ outHubVirtualNetworkId | string |
                 "activeActive": false,
                 "enableBgpRouteTranslationForNat": false,
                 "enableDnsForwarding": false,
-                "asn": 65515,
                 "bgpPeeringAddress": "",
                 "bgpsettings": {
                     "asn": 65515,
@@ -527,7 +526,6 @@ outHubVirtualNetworkId | string |
                 "activeActive": false,
                 "enableBgpRouteTranslationForNat": false,
                 "enableDnsForwarding": false,
-                "asn": "65515",
                 "bgpPeeringAddress": "",
                 "bgpsettings": {
                     "asn": "65515",

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
@@ -203,7 +203,6 @@ param parVpnGatewayConfig object = {
   activeActive: false
   enableBgpRouteTranslationForNat: false
   enableDnsForwarding: false
-  asn: 65515
   bgpPeeringAddress: ''
   bgpsettings: {
     asn: 65515
@@ -226,7 +225,6 @@ param parExpressRouteGatewayConfig object = {
   activeActive: false
   enableBgpRouteTranslationForNat: false
   enableDnsForwarding: false
-  asn: '65515'
   bgpPeeringAddress: ''
   bgpsettings: {
     asn: '65515'

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.all.json
@@ -175,7 +175,6 @@
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
-        "asn": "65515",
         "bgpPeeringAddress": "",
         "bgpsettings": {
           "asn": "65515",
@@ -195,7 +194,6 @@
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
-        "asn": "65515",
         "bgpPeeringAddress": "",
         "bgpsettings": {
           "asn": "65515",

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.min.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.min.json
@@ -71,7 +71,6 @@
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
-        "asn": "65515",
         "bgpPeeringAddress": "",
         "bgpsettings": {
           "asn": "65515",
@@ -91,7 +90,6 @@
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
-        "asn": "65515",
         "bgpPeeringAddress": "",
         "bgpsettings": {
           "asn": "65515",

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.all.json
@@ -137,7 +137,6 @@
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
-        "asn": "65515",
         "bgpPeeringAddress": "",
         "bgpsettings": {
           "asn": "65515",
@@ -157,7 +156,6 @@
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
-        "asn": "65515",
         "bgpPeeringAddress": "",
         "bgpsettings": {
           "asn": "65515",

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.min.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.min.json
@@ -107,7 +107,6 @@
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
-        "asn": "65515",
         "bgpPeeringAddress": "",
         "bgpsettings": {
           "asn": "65515",
@@ -127,7 +126,6 @@
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
-        "asn": "65515",
         "bgpPeeringAddress": "",
         "bgpsettings": {
           "asn": "65515",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
Default parameter object `parVpnGatewayConfig` and `parExpressRouteGatewayConfig` got the property `asn` defined both directly on the object and as a child prop to `bgpsettings`.

But the  `asn` property is never used by the hubnetwork module, only the `bgpsettings` is passed when creating all vgw.
[https://learn.microsoft.com/en-us/azure/templates/microsoft.network/virtualnetworkgateways](https://learn.microsoft.com/en-us/azure/templates/microsoft.network/virtualnetworkgateways)

## This PR fixes/adds/changes/removes

1. Removes the `asn` property from `parVpnGatewayConfig` and `parExpressRouteGatewayConfig` 

### Breaking Changes

None

## Testing Evidence

Changes has no impact on the resources created.

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
