### PR TITLE
Fixes #517 by making the deployment name for the recently added module unique on the zones resource ID

### DIFF
--- a/infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep
+++ b/infra-as-code/bicep/orchestration/hubPeeredSpoke/hubPeeredSpoke.bicep
@@ -162,7 +162,7 @@ module modSpokeNetworking '../../modules/spokeNetworking/spokeNetworking.bicep' 
 // Module - Private DNS Zone Virtual Network Link to Spoke
 module modPrivateDnsZoneLinkToSpoke '../../modules/privateDnsZoneLinks/privateDnsZoneLinks.bicep' = [for zones in parPrivateDnsZoneResourceIds: if (!empty(parPrivateDnsZoneResourceIds)) {
   scope: resourceGroup(split(zones, '/')[1], split(zones, '/')[4] )
-  name: varModuleDeploymentNames.modPrivateDnsZoneLinkToSpoke
+  name: take('${varModuleDeploymentNames.modPrivateDnsZoneLinkToSpoke}-${uniqueString(zones)}', 64)
   params: {
      parPrivateDnsZoneResourceIds: parPrivateDnsZoneResourceIds
      parSpokeVirtualNetworkResourceId: modSpokeNetworking.outputs.outSpokeVirtualNetworkId


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixes #517 by making the deployment name for the recently added module unique on the zones resource ID

## This PR fixes/adds/changes/removes

1. Fixes #517 by making the deployment name for the recently added module unique on the zones resource ID

### Breaking Changes

None

## Testing Evidence

Validates locally fine with multiple zones in the parameter array

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [x] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [x] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
