### PR TITLE
ALZ-Bicep-Accelerator Register missing resource provider

### DIFF
--- a/accelerator/pipeline-scripts/Deploy-ALZMGDiagnosticSettings.ps1
+++ b/accelerator/pipeline-scripts/Deploy-ALZMGDiagnosticSettings.ps1
@@ -6,6 +6,9 @@ param (
   [String]$TopLevelMGPrefix = "$($env:TOP_LEVEL_MG_PREFIX)",
 
   [Parameter()]
+  [String]$ManagementSubscriptionId = "$($env:MANAGEMENT_SUBSCRIPTION_ID)",
+
+  [Parameter()]
   [String]$TemplateFile = "upstream-releases\$($env:UPSTREAM_RELEASE_VERSION)\infra-as-code\bicep\orchestration\mgDiagSettingsAll\mgDiagSettingsAll.bicep",
 
   [Parameter()]
@@ -25,5 +28,9 @@ $inputObject = @{
   WhatIf                = $WhatIfEnabled
   Verbose               = $true
 }
+
+# Registering 'Microsoft.Insights' resource provider on the Management subscription
+Select-AzSubscription -SubscriptionId $ManagementSubscriptionId
+Register-AzResourceProvider -ProviderNamespace 'Microsoft.Insights'
 
 New-AzManagementGroupDeployment @inputObject

--- a/accelerator/pipeline-scripts/Deploy-ALZMGDiagnosticSettings.ps1
+++ b/accelerator/pipeline-scripts/Deploy-ALZMGDiagnosticSettings.ps1
@@ -31,6 +31,21 @@ $inputObject = @{
 
 # Registering 'Microsoft.Insights' resource provider on the Management subscription
 Select-AzSubscription -SubscriptionId $ManagementSubscriptionId
-Register-AzResourceProvider -ProviderNamespace 'Microsoft.Insights'
+
+$providers = @('Microsoft.insights')
+
+foreach ($provider in $providers ){
+  $providerStatus= (Get-AzResourceProvider -ListAvailable | Where-Object ProviderNamespace -eq $provider).registrationState
+  if($providerStatus -ne 'Registered'){
+    Write-Host "`n Registering the '$provider' provider"
+    Register-AzResourceProvider -ProviderNamespace $provider
+    do {
+      $providerStatus= (Get-AzResourceProvider -ListAvailable | Where-Object ProviderNamespace -eq $provider).registrationState
+      Write-Host "Waiting for the '$provider' provider registration to complete....waiting 10 seconds"
+      Start-Sleep -Seconds 10
+    } until ($providerStatus -eq 'Registered')
+    Write-Host "`n The '$provider' has been registered successfully"
+  }
+}
 
 New-AzManagementGroupDeployment @inputObject

--- a/accelerator/pipeline-scripts/Deploy-ALZMGDiagnosticSettings.ps1
+++ b/accelerator/pipeline-scripts/Deploy-ALZMGDiagnosticSettings.ps1
@@ -35,16 +35,24 @@ Select-AzSubscription -SubscriptionId $ManagementSubscriptionId
 $providers = @('Microsoft.insights')
 
 foreach ($provider in $providers ){
+  $iterationCount = 0
+  $maxIterations = 30
   $providerStatus= (Get-AzResourceProvider -ListAvailable | Where-Object ProviderNamespace -eq $provider).registrationState
   if($providerStatus -ne 'Registered'){
     Write-Output "`n Registering the '$provider' provider"
     Register-AzResourceProvider -ProviderNamespace $provider
     do {
       $providerStatus= (Get-AzResourceProvider -ListAvailable | Where-Object ProviderNamespace -eq $provider).registrationState
+      $iterationCount++
       Write-Output "Waiting for the '$provider' provider registration to complete....waiting 10 seconds"
       Start-Sleep -Seconds 10
-    } until ($providerStatus -eq 'Registered')
-    Write-Output "`n The '$provider' has been registered successfully"
+    } until ($providerStatus -eq 'Registered' -and $iterationCount -ne $maxIterations)
+    if($iterationCount -ne $maxIterations){
+      Write-Output "`n The '$provider' has been registered successfully"
+    }
+    else{
+      Write-Output "`n The '$provider' has not been registered successfully"
+    }
   }
 }
 

--- a/accelerator/pipeline-scripts/Deploy-ALZMGDiagnosticSettings.ps1
+++ b/accelerator/pipeline-scripts/Deploy-ALZMGDiagnosticSettings.ps1
@@ -37,14 +37,14 @@ $providers = @('Microsoft.insights')
 foreach ($provider in $providers ){
   $providerStatus= (Get-AzResourceProvider -ListAvailable | Where-Object ProviderNamespace -eq $provider).registrationState
   if($providerStatus -ne 'Registered'){
-    Write-Host "`n Registering the '$provider' provider"
+    Write-Output "`n Registering the '$provider' provider"
     Register-AzResourceProvider -ProviderNamespace $provider
     do {
       $providerStatus= (Get-AzResourceProvider -ListAvailable | Where-Object ProviderNamespace -eq $provider).registrationState
-      Write-Host "Waiting for the '$provider' provider registration to complete....waiting 10 seconds"
+      Write-Output "Waiting for the '$provider' provider registration to complete....waiting 10 seconds"
       Start-Sleep -Seconds 10
     } until ($providerStatus -eq 'Registered')
-    Write-Host "`n The '$provider' has been registered successfully"
+    Write-Output "`n The '$provider' has been registered successfully"
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixes issue Azure/Azure-Landing-Zones#2751 

## This PR fixes/adds/changes/removes

1. Adds logic to check for the 'Microsoft.Insights' resource provider

### Breaking Changes

N/A

## Testing Evidence

Cannot unregister the Microsoft.Insights provider so used another provider just for testing 

![image](https://github.com/Azure/ALZ-Bicep/assets/38246040/df3fc71d-6408-424a-8d45-608cff4572ec)


## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [X] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [X] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [X] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
