### PR TITLE
Add paths in push trigger for accelerator workflows

### DIFF
--- a/accelerator/.github/workflows/alz-bicep-1-core.yml
+++ b/accelerator/.github/workflows/alz-bicep-1-core.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "config/custom-parameters/managementGroups.parameters.all.json"
+      - "config/custom-parameters/resourceGroupLoggingAndSentinel.parameters.all.json"
+      - "config/custom-parameters/logging.parameters.all.json"
+      - "config/custom-parameters/customPolicyDefinitions.parameters.all.json"
+      - "config/custom-parameters/customRoleDefinitions.parameters.all.json"
+      - "config/custom-parameters/mgDiagSettingsAll.parameters.all.json"
   pull_request:
     branches:
       - "main"

--- a/accelerator/.github/workflows/alz-bicep-2-policyassignments.yml
+++ b/accelerator/.github/workflows/alz-bicep-2-policyassignments.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "config/custom-parameters/alzDefaultPolicyAssignments.parameters.all.json"
   pull_request:
     branches:
       - "main"

--- a/accelerator/.github/workflows/alz-bicep-3-subplacement.yml
+++ b/accelerator/.github/workflows/alz-bicep-3-subplacement.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "config/custom-parameters/subPlacementAll.parameters.all.json"
   pull_request:
     branches:
       - "main"

--- a/accelerator/.github/workflows/alz-bicep-4a-hubspoke.yml
+++ b/accelerator/.github/workflows/alz-bicep-4a-hubspoke.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "config/custom-parameters/resourceGroupConnectivity.parameters.all.json"
+      - "config/custom-parameters/hubNetworking.parameters.all.json"
   pull_request:
     branches:
       - "main"

--- a/accelerator/.github/workflows/alz-bicep-4b-vwan.yml
+++ b/accelerator/.github/workflows/alz-bicep-4b-vwan.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "config/custom-parameters/resourceGroupConnectivity.parameters.all.json"
+      - "config/custom-parameters/vwanConnectivity.parameters.all.json"
   pull_request:
     branches:
       - "main"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Adding back paths in push trigger for accelerator workflows so not all workflows will run deployment regardless of where the change was made. 

## This PR fixes/adds/changes/removes

1. This fixed bug reported in Azure/Azure-Landing-Zones#2749 

### Breaking Changes

## Testing Evidence

## As part of this Pull Request I have

- [ x ] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ x ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ x ] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ x ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [ x ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ x ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
