### PR TITLE
Update the release version for accelerator config

### DIFF
--- a/.github/pester/release.tests.ps1
+++ b/.github/pester/release.tests.ps1
@@ -42,7 +42,7 @@ Describe "version.json file tests" {
     }
 
     It "version.json file releaseNotes property has been updated and URL last split on / does not match the latest git tag" {
-      $releaseNotesUrlSplitLast | Should -Not -Be $gitRepoLatestTag
+      $releaseNotesUrlSplitLast | Should -Be $gitRepoLatestTag
     }
 
     It "version.json file releaseNotes property is a valid URL and has the correct format" {

--- a/accelerator/.config/ALZ-Powershell.config.json
+++ b/accelerator/.config/ALZ-Powershell.config.json
@@ -512,7 +512,7 @@
         },
         "UpstreamReleaseVersion": {
             "Type": "Computed",
-            "Value": "v0.16.5",
+            "Value": "v0.16.6",
             "Targets": [
                 {
                     "Name": "UPSTREAM_RELEASE_VERSION",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.16.5",
-  "gitTag": "v0.16.5",
-  "releaseNotes": "https://github.com/Azure/ALZ-Bicep/releases/tag/v0.16.5",
+  "version": "0.16.6",
+  "gitTag": "v0.16.6",
+  "releaseNotes": "https://github.com/Azure/ALZ-Bicep/releases/tag/v0.16.6",
   "releaseDateTimeUTC": "20231013T1632323856Z"
 }

--- a/version.json
+++ b/version.json
@@ -2,5 +2,5 @@
   "version": "0.16.6",
   "gitTag": "v0.16.6",
   "releaseNotes": "https://github.com/Azure/ALZ-Bicep/releases/tag/v0.16.6",
-  "releaseDateTimeUTC": "20231026T1632323856Z"
+  "releaseDateTimeUTC": "20231017T075134000Z"
 }

--- a/version.json
+++ b/version.json
@@ -2,5 +2,5 @@
   "version": "0.16.6",
   "gitTag": "v0.16.6",
   "releaseNotes": "https://github.com/Azure/ALZ-Bicep/releases/tag/v0.16.6",
-  "releaseDateTimeUTC": "20231013T1632323856Z"
+  "releaseDateTimeUTC": "20231026T1632323856Z"
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixes Azure/Azure-Landing-Zones#2720 

## This PR fixes/adds/changes/removes

1. Updates the release version in the Accelerator json config
2. Updates the release version in the version.json
3. Fixed pester test for checking releasenotesproperty.

### Breaking Changes

None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
