### PR TITLE
Automation account public network access option

### DIFF
--- a/infra-as-code/bicep/modules/logging/generateddocs/logging.bicep.md
+++ b/infra-as-code/bicep/modules/logging/generateddocs/logging.bicep.md
@@ -16,6 +16,7 @@ parLogAnalyticsWorkspaceLinkAutomationAccount | No       | Log Analytics Workspa
 parAutomationAccountName | No       | Automation account name.
 parAutomationAccountLocation | No       | Automation Account region name. - Ensure the regions selected is a supported mapping as per: https://docs.microsoft.com/azure/automation/how-to/region-mappings.
 parAutomationAccountUseManagedIdentity | No       | Automation Account - use managed identity.
+parAutomationAccountPublicNetworkAccess | No       | Automation Account - Public network access.
 parTags        | No       | Tags you would like to be applied to all resources in this module.
 parAutomationAccountTags | No       | Tags you would like to be applied to Automation Account.
 parLogAnalyticsWorkspaceTags | No       | Tags you would like to be applied to Log Analytics Workspace.
@@ -105,6 +106,14 @@ Automation Account region name. - Ensure the regions selected is a supported map
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
 
 Automation Account - use managed identity.
+
+- Default value: `True`
+
+### parAutomationAccountPublicNetworkAccess
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Automation Account - Public network access.
 
 - Default value: `True`
 
@@ -208,6 +217,9 @@ outAutomationAccountId | string |
             "value": "[resourceGroup().location]"
         },
         "parAutomationAccountUseManagedIdentity": {
+            "value": true
+        },
+        "parAutomationAccountPublicNetworkAccess": {
             "value": true
         },
         "parTags": {

--- a/infra-as-code/bicep/modules/logging/logging.bicep
+++ b/infra-as-code/bicep/modules/logging/logging.bicep
@@ -77,6 +77,9 @@ param parAutomationAccountLocation string = resourceGroup().location
 @sys.description('Automation Account - use managed identity.')
 param parAutomationAccountUseManagedIdentity bool = true
 
+@sys.description('Automation Account - Public network access.')
+param parAutomationAccountPublicNetworkAccess bool = true
+
 @sys.description('Tags you would like to be applied to all resources in this module.')
 param parTags object = {}
 
@@ -103,11 +106,12 @@ resource resAutomationAccount 'Microsoft.Automation/automationAccounts@2022-08-0
     type: 'SystemAssigned'
   } : null
   properties: {
-    sku: {
-      name: 'Basic'
-    }
     encryption: {
       keySource: 'Microsoft.Automation'
+    }
+    publicNetworkAccess: parAutomationAccountPublicNetworkAccess
+    sku: {
+      name: 'Basic'
     }
   }
 }

--- a/infra-as-code/bicep/modules/logging/parameters/logging.parameters.all.json
+++ b/infra-as-code/bicep/modules/logging/parameters/logging.parameters.all.json
@@ -43,6 +43,9 @@
     "parAutomationAccountUseManagedIdentity": {
       "value": true
     },
+    "parAutomationAccountPublicNetworkAccess": {
+      "value": true
+    },
     "parTags": {
       "value": {
         "Environment": "Live"

--- a/infra-as-code/bicep/modules/logging/parameters/mc-logging.parameters.all.json
+++ b/infra-as-code/bicep/modules/logging/parameters/mc-logging.parameters.all.json
@@ -40,6 +40,9 @@
     "parAutomationAccountUseManagedIdentity": {
       "value": true
     },
+    "parAutomationAccountPublicNetworkAccess": {
+      "value": true
+    },
     "parTags": {
       "value": {
         "Environment": "Live"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

PR adds option to disable public network access on the automation account in the logging module.

## This PR fixes/adds/changes/removes

1. Adds parameter to logging module `parAutomationAccountPublicNetworkAccess` as requested in #664

### Breaking Changes

1. None. Default value is still the same.


## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
