### PR TITLE
chore: remove un-required version number and tidy docs

### DIFF
--- a/accelerator/.config/ALZ-Powershell.config.json
+++ b/accelerator/.config/ALZ-Powershell.config.json
@@ -512,7 +512,7 @@
         },
         "UpstreamReleaseVersion": {
             "Type": "Computed",
-            "Value": "v0.16.6",
+            "Value": "{REPLACED_BY_ALZ_POWERSHELL_MODULE}",
             "Targets": [
                 {
                     "Name": "UPSTREAM_RELEASE_VERSION",

--- a/docs/wiki/Accelerator.md
+++ b/docs/wiki/Accelerator.md
@@ -219,7 +219,7 @@ With the ALZ Accelerator framework, we have designed the pipelines and directory
 
 1. Using the ALZ PowerShell Module, there is a cmdlet called `Get-ALZBicepRelease`. This will download a specified release version from the remote ALZ-Bicep repository and pull down to the local directory where your Accelerator framework was initially deployed.
 
-    Here is an example of using the cmdlet to pull down version v0.16.5:
+    Here is an example of using the cmdlet to pull down version v0.16.6:
 
     ```powershell
     Get-ALZGithubRelease -githubRepoUrl "https://github.com/Azure/ALZ-Bicep" -release "v0.16.6" -directoryForReleases "C:\Repos\ALZ\accelerator\upstream-releases\"
@@ -228,7 +228,7 @@ With the ALZ Accelerator framework, we have designed the pipelines and directory
 1. Once the ALZ Bicep release has been downloaded, you will need to update `upstream-releases-version` within the environment variables file (.env) with the version number of the release that you just downloaded. For example, if you downloaded v0.16.5, you would update the file with the following:
 
     ```text
-    UPSTREAM_RELEASE_VERSION="v0.16.5"
+    UPSTREAM_RELEASE_VERSION="v0.16.6"
     ```
 
 1. You can now deploy the updated modules.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR removes a version number that is no longer required. The ALZ PowerShell module now handles the version. The config setting need to be retained in the config.json for the time being.

## This PR fixes/adds/changes/removes

1. Azure/Azure-Landing-Zones#2714 (The actual fix is in https://github.com/Azure/ALZ-PowerShell-Module/pull/88), but this is part of the same thing

### Breaking Changes

1. None

## Testing Evidence

Generated env file now contains the correct version even when pulling the wrong config.

<img width="281" alt="image" src="https://github.com/Azure/ALZ-Bicep/assets/1612200/b3bb40c1-f369-4d16-a7a5-3b9e8b66ad3e">



## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [x] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [x] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
