### PR TITLE
Added missing parTags to the private zone links

### DIFF
--- a/infra-as-code/bicep/modules/privateDnsZones/privateDnsZones.bicep
+++ b/infra-as-code/bicep/modules/privateDnsZones/privateDnsZones.bicep
@@ -185,6 +185,7 @@ resource resVirtualNetworkLink 'Microsoft.Network/privateDnsZones/virtualNetwork
     }
   }
   dependsOn: resPrivateDnsZones
+  tags: parTags
 }]
 
 resource resVirtualNetworkLinkFailover 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = [for privateDnsZoneName in varPrivateDnsZonesMerge: if (!empty(parVirtualNetworkIdToLinkFailover)) {
@@ -197,6 +198,7 @@ resource resVirtualNetworkLinkFailover 'Microsoft.Network/privateDnsZones/virtua
     }
   }
   dependsOn: resPrivateDnsZones
+  tags: parTags
 }]
 
 module modCustomerUsageAttribution '../../CRML/customerUsageAttribution/cuaIdResourceGroup.bicep' = if (!parTelemetryOptOut) {


### PR DESCRIPTION
# Overview/Summary

Tags are not passed to the private dns link modules which breaks deployment when there are policies in place requiring a tag, see #697 

## This PR fixes/adds/changes/removes

Adds `parTags` parameter to `resVirtualNetworkLink` and `resVirtualNetworkLinkFailover`

### Breaking Changes

None

## Testing Evidence

1. Deploy "Require a tag and its value on resources" policy to require `Environment` tag.
2. Deploy the hub module.
3. The deployment fails, sometimes with weird error like "FirewallPolicyUpdateFailed: Put on Firewall Policy afwp-poc-hub-euw Failed with 1 faulted referenced firewalls", sometimes with "RequestDisallowedByPolicy: Resource 'link-vqlscyvvqtsm4' was disallowed by policy." depending on the state.
4. Apply the fix and redeploy -> the deployment succeeds.
