### PR TITLE
Bug: Fix deployment toggle to hub-spoke by adding AzBastionEnabled boolean to resBastionSubnetRef

### DIFF
--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
@@ -396,7 +396,7 @@ module modBastionPublicIp '../publicIp/publicIp.bicep' = if (parAzBastionEnabled
   }
 }
 
-resource resBastionSubnetRef 'Microsoft.Network/virtualNetworks/subnets@2023-02-01' existing = {
+resource resBastionSubnetRef 'Microsoft.Network/virtualNetworks/subnets@2023-02-01' existing = if (parAzBastionEnabled) {
   parent: resHubVnet
   name: 'AzureBastionSubnet'
 }


### PR DESCRIPTION
# Overview/Summary
Was notified by @jamiepla1 of an issue dealing with `hubNetworking.parameters.all.json` file in the `infra-as-code\bicep\modules\hubNetworking\parameters\` directory when updating `parSubnets.value.name = AzureBastionSubnet`. Some customers might opt-out of keeping `AzureBastionSubnet` if `parAzBastionEnabled = false`, removing it from `parSubnets` still gives you errors. 

The finding was the missing toggle located in `hubNetworking.bicep` file in the `infra-as-code/bicep/modules/hubNetworking` directory to update the `resBastionSubnetRef` resource declaration. 

## This PR fixes/adds/changes/removes

Adding `if (parAzBastionEnabled)` to `infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep`: Updated the `resBastionSubnetRef` resource declaration. (hubNetworking.bicep: resBastionSubnetRef)

Allows you to remove `AzureBastionSubnet` from `hubNetworking.parameters.all.json` file in the `infra-as-code\bicep\modules\hubNetworking\parameters\` directory when updating `parSubnets.value.name = AzureBastionSubnet`

### Breaking Changes

N/A

## Testing Evidence
*Before Fix*
The deployment 'alz-Hub-and-SpokeDeploy-20231206T1512101164Z'
     | failed with error(s). Showing 1 out of 1 error(s). Status Message:
     | Resource
     | /subscriptions/88888888-8888-8888-8888-888888888888/resourceGroups/rg-alz-connectivity/providers/Microsoft.Network/virtualNetworks/alz-hub-norwayeast/subnets/AzureBastionSubnet not found. (Code: NotFound) 

*After Fix*
![image](https://github.com/Azure/ALZ-Bicep/assets/19664186/df7a0fc2-cc43-49ad-8097-1cfbd6d5fa8a)


## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)

