### PR TITLE
Add DdosEnabled toggle and fix logic modPolicyAssignmentConnEnableDdos

### DIFF
--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
@@ -34,7 +34,10 @@ param parAutomationAccountName string = 'alz-automation-account'
 @sys.description('An e-mail address that you want Microsoft Defender for Cloud alerts to be sent to.')
 param parMsDefenderForCloudEmailSecurityContact string = 'security_contact@replace_me.com'
 
-@sys.description('ID of the DdosProtectionPlan which will be applied to the Virtual Networks. If left empty, the policy Enable-DDoS-VNET will not be assigned at connectivity or landing zone Management Groups to avoid VNET deployment issues.')
+@sys.description('Switch to enable/disable DDoS Network Protection deployment. True will enforce policy Enable-DDoS-VNET at connectivity or landing zone Management Groups. False will not enforce policy Enable-DDoS-VNET.')
+param parDdosEnabled bool = true
+
+@sys.description('ID of the DdosProtectionPlan which will be applied to the Virtual Networks.')
 param parDdosProtectionPlanId string = ''
 
 @sys.description('Resource ID of the Resource Group that conatin the Private DNS Zones. If left empty, the policy Deploy-Private-DNS-Zones will not be assigned to the corp Management Group.')
@@ -727,7 +730,7 @@ module modPolicyAssignmentConnEnableDdosVnet '../../../policy/assignments/policy
       }
     }
     parPolicyAssignmentIdentityType: varPolicyAssignmentEnableDDoSVNET.libDefinition.identity.type
-    parPolicyAssignmentEnforcementMode: parDisableAlzDefaultPolicies ? 'DoNotEnforce' : varPolicyAssignmentEnableDDoSVNET.libDefinition.properties.enforcementMode
+    parPolicyAssignmentEnforcementMode: !parDdosEnabled ? 'DoNotEnforce' : varPolicyAssignmentEnableDDoSVNET.libDefinition.properties.enforcementMode
     parPolicyAssignmentIdentityRoleDefinitionIds: [
       varRbacRoleDefinitionIds.networkContributor
     ]
@@ -960,7 +963,7 @@ module modPolicyAssignmentLzsEnableDdosVnet '../../../policy/assignments/policyA
       }
     }
     parPolicyAssignmentIdentityType: varPolicyAssignmentEnableDDoSVNET.libDefinition.identity.type
-    parPolicyAssignmentEnforcementMode: parDisableAlzDefaultPolicies ? 'DoNotEnforce' : varPolicyAssignmentEnableDDoSVNET.libDefinition.properties.enforcementMode
+    parPolicyAssignmentEnforcementMode: !parDdosEnabled ? 'DoNotEnforce' : varPolicyAssignmentEnableDDoSVNET.libDefinition.properties.enforcementMode
     parPolicyAssignmentIdentityRoleDefinitionIds: [
       varRbacRoleDefinitionIds.networkContributor
     ]

--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/parameters/alzDefaultPolicyAssignments.parameters.all.json
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/parameters/alzDefaultPolicyAssignments.parameters.all.json
@@ -8,6 +8,9 @@
     "parTopLevelManagementGroupSuffix": {
       "value": ""
     },
+    "parDdosEnabled": {
+      "value": true
+    },
     "parPlatformMgAlzDefaultsEnable": {
       "value": true
     },

--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/parameters/alzDefaultPolicyAssignments.parameters.min.json
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/parameters/alzDefaultPolicyAssignments.parameters.min.json
@@ -5,6 +5,9 @@
         "parTopLevelManagementGroupPrefix": {
             "value": "alz"
         },
+        "parDdosEnabled": {
+          "value": true
+        },
         "parLogAnalyticsWorkSpaceAndAutomationAccountLocation": {
             "value": "eastus"
         },


### PR DESCRIPTION
# Overview/Summary

Closes Bug #596 and @jamiepla1 flagged this. Policy issue around `parDdosProtectionPlanId`, because by default `parDdosProtectionPlanId` is populated during creation of ALZ-Bicep Accelerator. If you don't clean (empty) or catch this, it will deploy a policy `Enable-DDoS-VNET`. This will block the creation of Virtual Networks in the Connectivity Subscription if you disable/false `parDdosEnabled` in other areas of ALZ-Bicep. To get around this, simply adding the boolean/toggle of `parDdosEnabled` will now make this not enable by default even if `parDdosProtectionPlanId`. Making this uniformed across the ALZ-Bicep deployment.

## This PR fixes/adds/changes/removes
```
@sys.description('Switch to enable/disable DDoS Network Protection deployment. True will enforce policy Enable-DDoS-VNET at connectivity or landing zone Management Groups. False will not enforce policy Enable-DDoS-VNET.')
param parDdosEnabled bool = true
```

Within the Module `modPolicyAssignmentConnEnableDdosVnet` the variable `parPolicyAssignmentIdentityType`, `parDisableAlzDefaultPolicies` was removed in favor of having `parDdosEnabled`. This allows the policy to be added, but not inforced if `parDdosEnabled` is false. If the end-user forgets to set `parDdosEnabled`, then they will get an error when deploying networking within Connectivity Subscription. 

`parPolicyAssignmentEnforcementMode: !parDdosEnabled ? 'DoNotEnforce' : varPolicyAssignmentEnableDDoSVNET.libDefinition.properties.enforcementMode`
    
*When deploying Hub in Connectivity Subscription the following happens if `Enable-DDoS-VNET` is enforced*
```
The deployment 'alz-Hub-and-SpokeDeploy-20231209T1712405048Z'
     | failed with error(s). Showing 1 out of 1 error(s). Status Message:
     | Resource
     | /subscriptions/*******-****-****-****-************/resourceGroups/rg-alz-connectivity/providers/Microsoft.Network/ddosProtectionPlans/alz-ddos-plan referenced by resource /subscriptions/*******-****-****-****-************/resourceGroups/rg-alz-connectivity/providers/Microsoft.Network/virtualNetworks/alz-hub-swedencentral was not found. Please make sure that the referenced resource exists. (Code: InvalidGlobalResourceReference)
``` 

**Disclaimer
It should be documented that DDoS Protection is a recommendation, therefor the policy is in a non-compliant state as when it is turned to `parDdosEnabled = false`, as it is not being enforced. 
![image](https://github.com/Azure/ALZ-Bicep/assets/19664186/9ea30e16-74fd-4b65-8eb3-34ad3e6aaa1c)

### Breaking Changes

1. N/A

## Testing Evidence

![image](https://github.com/Azure/ALZ-Bicep/assets/19664186/fbc82063-6aab-4852-b4fb-10572d7595b0)

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
