### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/update-policy-china.yml
+++ b/.github/workflows/update-policy-china.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           CHECK_GIT_STATUS=($(git status -s))
           git status -s
-          echo "::set-output name=changes::${#CHECK_GIT_STATUS[@]}"
+          echo "changes=${#CHECK_GIT_STATUS[@]}" >> $GITHUB_OUTPUT
         working-directory: ${{ github.repository }}
 
       - name: Add files, commit and push


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter`