### PR TITLE
Add global region to Enforce Sovereign Global default

### DIFF
--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
@@ -522,7 +522,7 @@ module modPolicyAssignmentIntRootEnforceSovereigntyGlobal '../../../policy/assig
     parPolicyAssignmentParameterOverrides: {
       listOfAllowedLocations: {
         #disable-next-line no-loc-expr-outside-params
-        value: !(empty(parTopLevelPolicyAssignmentSovereigntyGlobal.parListOfAllowedLocations)) ? parTopLevelPolicyAssignmentSovereigntyGlobal.parListOfAllowedLocations : array(deployment().location)
+        value: !(empty(parTopLevelPolicyAssignmentSovereigntyGlobal.parListOfAllowedLocations)) ? parTopLevelPolicyAssignmentSovereigntyGlobal.parListOfAllowedLocations : array(deployment().location, 'global')
       }
     }
     parPolicyAssignmentIdentityType: varPolicyAssignmentEnforceSovereignGlobal.libDefinition.identity.type


### PR DESCRIPTION
This pull request includes a modification to the `parPolicyAssignmentParameterOverrides` in the `alzDefaultPolicyAssignments.bicep` file. The change updates the default value for `listOfAllowedLocations` to include 'global' if `parTopLevelPolicyAssignmentSovereigntyGlobal.parListOfAllowedLocations` is empty. 

* [`infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep`](diffhunk://#diff-90b5177f0a982776fb0b5ac49607081d27a7285e686a0308d588520f1b89c0aeL525-R525): Modified the `listOfAllowedLocations` value in `parPolicyAssignmentParameterOverrides` to include 'global' in the default array if `parTopLevelPolicyAssignmentSovereigntyGlobal.parListOfAllowedLocations` is empty.