### PR TITLE
Update vwanConnectivity.bicep

### DIFF
--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -467,7 +467,7 @@ resource resErGateway 'Microsoft.Network/expressRouteGateways@2023-02-01' = [for
 
 // Create a Virtual Network Gateway resource lock if gateway.name is not equal to noconfigVpn or noconfigEr and parGlobalResourceLock.kind != 'None' or if parVpnGatewayLock.kind != 'None'
 resource resErGatewayLock 'Microsoft.Authorization/locks@2020-05-01' = [for (hub, i) in parVirtualWanHubs: if ((parVirtualHubEnabled) && (hub.parExpressRouteGatewayEnabled) && (parExpressRouteGatewayLock.kind != 'None' || parGlobalResourceLock.kind != 'None')) {
-  scope: resVpnGateway[i]
+  scope: resErGateway[i]
   name: parExpressRouteGatewayLock.?name ?? '${resErGateway[i].name}-lock'
   properties: {
     level: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.kind : parExpressRouteGatewayLock.kind


### PR DESCRIPTION
# Overview/Summary

resErGatewayLock is improperly scoped on resVpnGateway. Updating to resErGateway

## This PR fixes/adds/changes/removes

1. #743 

## Testing Evidence

This is a small fix, you should be able to duplicate this with the latest release.

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [X] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
