### PR TITLE
Documentation: Enhancements and adjustments to documentation

### DIFF
--- a/infra-as-code/bicep/modules/mgDiagSettings/README.md
+++ b/infra-as-code/bicep/modules/mgDiagSettings/README.md
@@ -21,49 +21,67 @@ The inputs for this module are defined in `parameters/mgDiagSettings.parameters.
 
 ```bash
 # For Azure global regions
-az deployment mg create \
-  --template-file infra-as-code/bicep/modules/mgDiagSettings/mgDiagSettings.bicep \
-  --parameters @infra-as-code/bicep/modules/mgDiagSettings/parameters/mgDiagSettings.parameters.all.json \
-  --location eastus \
-  --management-group-id alz
+
+dateYMD=$(date +%Y%m%dT%H%M%S%NZ)
+NAME="alz-mgDiagSettings-${dateYMD}"
+LOCATION="eastus"
+TEMPLATEFILE="infra-as-code/bicep/modules/mgDiagSettings/mgDiagSettings.bicep"
+PARAMETERS="infra-as-code/bicep/modules/mgDiagSettings/parameters/mgDiagSettings.parameters.all.json"
+# Set the top level Management Group ID in accordance to your environment. This example assumes default 'alz'.
+MGID="alz"
+
+az deployment mg create --name $NAME --location $LOCATION --template-file $TEMPLATEFILE --parameters $PARAMETERS --management-group-id $MGID
 ```
 
 OR
 
 ```bash
 # For Azure China regions
-az deployment mg create \
-  --template-file infra-as-code/bicep/modules/mgDiagSettings/mgDiagSettings.bicep \
-  --parameters @infra-as-code/bicep/modules/mgDiagSettings/parameters/mgDiagSettings.parameters.all.json \
-  --location chinaeast2 \
-  --management-group-id alz
+
+dateYMD=$(date +%Y%m%dT%H%M%S%NZ)
+NAME="alz-mgDiagSettings-${dateYMD}"
+LOCATION="chinaeast2"
+TEMPLATEFILE="infra-as-code/bicep/modules/mgDiagSettings/mgDiagSettings.bicep"
+PARAMETERS="infra-as-code/bicep/modules/mgDiagSettings/parameters/mgDiagSettings.parameters.all.json"
+# Set the top level Management Group ID in accordance to your environment. This example assumes default 'alz'.
+MGID="alz"
+
+az deployment mg create --name $NAME --location $LOCATION --template-file $TEMPLATEFILE --parameters $PARAMETERS --management-group-id $MGID
 ```
 
 ### PowerShell
 
 ```powershell
 # For Azure global regions
-New-AzManagementGroupDeployment `
-  -TemplateFile infra-as-code/bicep/modules/mgDiagSettings/mgDiagSettings.bicep `
-  -TemplateParameterFile @infra-as-code/bicep/modules/mgDiagSettings/parameters/mgDiagSettings.parameters.all.json `
-  -Location eastus `
-  -ManagementGroupId alz
+
+$inputObject = @{
+  DeploymentName        = 'alz-mgDiagSettings-{0}' -f (-join (Get-Date -Format 'yyyyMMddTHHMMssffffZ')[0..63])
+  Location              = 'eastus'
+  TemplateFile          = "infra-as-code/bicep/modules/mgDiagSettings/mgDiagSettings.bicep"
+  TemplateParameterFile = 'infra-as-code/bicep/modules/mgDiagSettings/parameters/mgDiagSettings.parameters.all.json'
+  ManagementGroupId     = 'alz'
+}
+New-AzManagementGroupDeployment @inputObject
 ```
 
 OR
 
 ```powershell
 # For Azure China regions
-New-AzManagementGroupDeployment `
-  -TemplateFile infra-as-code/bicep/modules/mgDiagSettings/mgDiagSettings.bicep `
-  -TemplateParameterFile @infra-as-code/bicep/modules/mgDiagSettings/parameters/mgDiagSettings.parameters.all.json `
-  -Location chinaeast2 `
-  -ManagementGroupId alz
+
+$inputObject = @{
+  DeploymentName        = 'alz-mgDiagSettings-{0}' -f (-join (Get-Date -Format 'yyyyMMddTHHMMssffffZ')[0..63])
+  Location              = 'chinaeast2'
+  TemplateFile          = "infra-as-code/bicep/modules/mgDiagSettings/mgDiagSettings.bicep"
+  TemplateParameterFile = 'infra-as-code/bicep/modules/mgDiagSettings/parameters/mgDiagSettings.parameters.all.json'
+  ManagementGroupId     = 'alz'
+}
+New-AzManagementGroupDeployment @inputObject
 ```
 
 ## Validation
 
-To validate if Diagnostic Settings was correctly enabled for any specific management group, a REST API GET call can be used. Documentation and easy way to try this can be found in this link [(Management Group Diagnostic Settings - Get)](https://learn.microsoft.com/rest/api/monitor/management-group-diagnostic-settings/get?tabs=HTTP&tryIt=true&source=docs#code-try-0). There is currently not a direct way to validate this in the Azure Portal, Azure CLI or PowerShell.
+To validate if Diagnostic Settings were correctly enabled for any specific management group, a REST API GET call can be used. Documentation and easy way to try this can be found in this link [(Management Group Diagnostic Settings - Get)](https://learn.microsoft.com/rest/api/monitor/management-group-diagnostic-settings/get?tabs=HTTP&tryIt=true&source=docs#code-try-0). There is currently not a direct way to validate this in the Azure Portal or with Azure PowerShell or the Azure CLI.
 
 ## Bicep Visualizer
 

--- a/infra-as-code/bicep/modules/spokeNetworking/README.md
+++ b/infra-as-code/bicep/modules/spokeNetworking/README.md
@@ -1,5 +1,8 @@
 # Module: Spoke Networking
 
+> [!IMPORTANT]
+> We recommend utilizing the [Bicep Landing Zone Vending Module](https://github.com/Azure/bicep-lz-vending) in place of this Spoke Networking Module. Not only does the module handle spoke networking, but it also handles many other aspects of setting up the > foundational components of the application landing zones which are out of scope for this module.
+
 This module defines spoke networking based on the recommendations from the Azure Landing Zone Conceptual Architecture. If enabled spoke will route traffic to Hub Network with NVA.
 
 Module deploys the following resources:
@@ -7,14 +10,7 @@ Module deploys the following resources:
 - Virtual Network (Spoke VNet)
 - Route Table with route to NVA - if Firewall is enabled
 
-> ## Note
->
-> ### Orchestration
->
-> Consider using the `hubPeeredSpoke` orchestration module instead to simplify spoke networking deployment, VNET Peering, UDR configuration and Subscription placement in a single module. [infra-as-code/bicep/orchestration/hubPeeredSpoke](https://github.com/Azure/ALZ-Bicep/tree/main/infra-as-code/bicep/orchestration/hubPeeredSpoke)
->
-> ### Subnet Declaration
->
+> [!NOTE]
 > This module only deploys the skeleton of a virtual network. Subnet(s) are not created nor does this module support declaring them. This is a blank vNet with the expectation of handing it over to the app/workload team to create their subnet(s), etc. The ALZ-Bicep core team decided not to add subnet support due to:
 >
 > - Complexity of managing all of the subnet properties, including NSG, UDR, service endpoints, subnet delegations, etc.

--- a/infra-as-code/bicep/modules/spokeNetworking/README.md
+++ b/infra-as-code/bicep/modules/spokeNetworking/README.md
@@ -24,7 +24,7 @@ Module deploys the following resources:
 >
 > To customize spoke networking to include subnet declarations, we recommend the use of the following ordered methods:
 >
-> 1. [CARML](https://aka.ms/carml) - Utilize this mature Bicep repo for resource deployments
+> 1. [AVM](https://aka.ms/avm) - Utilize Azure Verified Modules to deploy the subnets
 > 2. [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) this repo and customize the modules accordingly
 > 3. Write your own custom module
 

--- a/infra-as-code/bicep/orchestration/hubPeeredSpoke/README.md
+++ b/infra-as-code/bicep/orchestration/hubPeeredSpoke/README.md
@@ -1,5 +1,9 @@
 # Module: Orchestration - hubPeeredSpoke - Spoke network, including peering to Hub (Hub & Spoke or Virtual WAN)
 
+> [!IMPORTANT]
+> We recommend utilizing the [Bicep Landing Zone Vending Module](https://github.com/Azure/bicep-lz-vending) in place of this Spoke Networking Module. Not only does the module handle spoke networking, but it also handles many other aspects of setting up the > foundational components of the application landing zones which are out of scope for this module.
+
+
 This module acts as an orchestration module that create and configures a spoke network to deliver the Azure Landing Zone Hub & Spoke architecture, for both traditional Hub & Spoke and Virtual WAN, which is also described in the wiki on the [Deployment Flow article](https://github.com/Azure/ALZ-Bicep/wiki/DeploymentFlow).
 
 Module deploys the following resources:

--- a/infra-as-code/bicep/orchestration/mgDiagSettingsAll/README.md
+++ b/infra-as-code/bicep/orchestration/mgDiagSettingsAll/README.md
@@ -83,6 +83,38 @@ In this example, the Diagnostic Settings are enabled on the management groups th
 
 > For the examples below we assume you have downloaded or cloned the Git repo as-is and are in the root of the repository as your selected directory in your terminal of choice.
 
+You will also need to ensure you have the Microsoft.Insights resource provider registered in the Management subscription.
+
+You can utilize this script to check if the resource provider is registered, and if not, register it:
+```powershell
+# Registering 'Microsoft.Insights' resource provider on the Management subscription
+Select-AzSubscription -SubscriptionId $ManagementSubscriptionId
+
+$providers = @('Microsoft.insights')
+
+foreach ($provider in $providers ) {
+  $iterationCount = 0
+  $maxIterations = 30
+  $providerStatus = (Get-AzResourceProvider -ListAvailable | Where-Object ProviderNamespace -eq $provider).registrationState
+  if ($providerStatus -ne 'Registered') {
+    Write-Output "`n Registering the '$provider' provider"
+    Register-AzResourceProvider -ProviderNamespace $provider
+    do {
+      $providerStatus = (Get-AzResourceProvider -ListAvailable | Where-Object ProviderNamespace -eq $provider).registrationState
+      $iterationCount++
+      Write-Output "Waiting for the '$provider' provider registration to complete....waiting 10 seconds"
+      Start-Sleep -Seconds 10
+    } until ($providerStatus -eq 'Registered' -and $iterationCount -ne $maxIterations)
+    if ($iterationCount -ne $maxIterations) {
+      Write-Output "`n The '$provider' has been registered successfully"
+    }
+    else {
+      Write-Output "`n The '$provider' has not been registered successfully"
+    }
+  }
+}
+```
+
 ### Azure CLI
 
 ```bash


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

General documentation enhancements and updates

Closes #764
Closes #765 

## This PR fixes/adds/changes/removes

This pull request primarily focuses on updating the documentation and instructions in several README files. It introduces recommendations for using the Bicep Landing Zone Vending Module instead of the current Spoke Networking Module, updates the method for deploying subnets, and adds instructions for registering the Microsoft.Insights resource provider in the Management subscription. 

Here are the key updates:

Recommendation to use Bicep Landing Zone Vending Module:

* [`infra-as-code/bicep/modules/spokeNetworking/README.md`](diffhunk://#diff-247fa44e2c1b33e9876c6d7d72c6c8d7f8a1eac1471612cf544d5d29dec23017R3-R13): Added a recommendation to use the [Bicep Landing Zone Vending Module](https://github.com/Azure/bicep-lz-vending) instead of the current Spoke Networking Module.
* [`infra-as-code/bicep/orchestration/hubPeeredSpoke/README.md`](diffhunk://#diff-2348788eaf459a3d08ac4f16a06fd4935b2a43c749b76f1bef4f20b67a31af64R3-R6): Similar recommendation added here.

Updates to deployment instructions:

* [`infra-as-code/bicep/modules/mgDiagSettings/README.md`](diffhunk://#diff-5778823e3f61951bfc56291e24044a49aaf128203054f14041faa910c652d0deL24-R84): Updated the deployment commands for Azure global regions and Azure China regions. The commands now use variables for better readability and maintainability.

Subnet deployment method update:

* [`infra-as-code/bicep/modules/spokeNetworking/README.md`](diffhunk://#diff-247fa44e2c1b33e9876c6d7d72c6c8d7f8a1eac1471612cf544d5d29dec23017L27-R23): Updated the recommended method for deploying subnets from CARML to AVM (Azure Verified Modules).

Registration of Microsoft.Insights resource provider:

* [`infra-as-code/bicep/orchestration/mgDiagSettingsAll/README.md`](diffhunk://#diff-390cdf6ff6a7bff1de8174b09af36140f52f1d30eaffe3e3613422d9c300d4a2R86-R117): Added a PowerShell script for checking and registering the Microsoft.Insights resource provider in the Management subscription.

### Breaking Changes

None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
