### PR TITLE
Sentinel onboarding via OnboardingStates API

### DIFF
--- a/infra-as-code/bicep/modules/logging/logging.bicep
+++ b/infra-as-code/bicep/modules/logging/logging.bicep
@@ -637,6 +637,13 @@ resource resDataCollectionRuleMDFCSQLLock 'Microsoft.Authorization/locks@2020-05
   }
 }
 
+// Onboard the Log Analytics Workspace to Sentinel if SecurityInsights is in parLogAnalyticsWorkspaceSolutions
+resource resSentinelOnboarding 'Microsoft.SecurityInsights/onboardingStates@2024-03-01' = if (contains(parLogAnalyticsWorkspaceSolutions, 'SecurityInsights')) {
+  name: 'default'
+  scope: resLogAnalyticsWorkspace
+  properties: {}
+}
+
 resource resLogAnalyticsWorkspaceSolutions 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = [for solution in parLogAnalyticsWorkspaceSolutions: {
   name: '${solution}(${resLogAnalyticsWorkspace.name})'
   location: parLogAnalyticsWorkspaceLocation

--- a/infra-as-code/bicep/modules/logging/logging.bicep
+++ b/infra-as-code/bicep/modules/logging/logging.bicep
@@ -240,7 +240,7 @@ resource resLogAnalyticsWorkspaceLock 'Microsoft.Authorization/locks@2020-05-01'
   }
 }
 
-resource resDataCollectionRuleVMInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
+resource resDataCollectionRuleVMInsights 'Microsoft.Insights/dataCollectionRules@2021-04-01' = {
   name: parDataCollectionRuleVMInsightsName
   location: parLogAnalyticsWorkspaceLocation
   properties: {
@@ -308,7 +308,7 @@ resource resDataCollectionRuleVMInsightsLock 'Microsoft.Authorization/locks@2020
   }
 }
 
-resource resDataCollectionRuleChangeTracking 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
+resource resDataCollectionRuleChangeTracking 'Microsoft.Insights/dataCollectionRules@2021-04-01' = {
   name: parDataCollectionRuleChangeTrackingName
   location: parLogAnalyticsWorkspaceLocation
   properties: {
@@ -579,7 +579,7 @@ resource resDataCollectionRuleChangeTrackingLock 'Microsoft.Authorization/locks@
   }
 }
 
-resource resDataCollectionRuleMDFCSQL'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
+resource resDataCollectionRuleMDFCSQL'Microsoft.Insights/dataCollectionRules@2021-04-01' = {
   name: parDataCollectionRuleMDFCSQLName
   location: parLogAnalyticsWorkspaceLocation
   properties: {

--- a/infra-as-code/bicep/modules/logging/logging.bicep
+++ b/infra-as-code/bicep/modules/logging/logging.bicep
@@ -240,7 +240,7 @@ resource resLogAnalyticsWorkspaceLock 'Microsoft.Authorization/locks@2020-05-01'
   }
 }
 
-resource resDataCollectionRuleVMInsights 'Microsoft.Insights/dataCollectionRules@2021-04-01' = {
+resource resDataCollectionRuleVMInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
   name: parDataCollectionRuleVMInsightsName
   location: parLogAnalyticsWorkspaceLocation
   properties: {
@@ -308,7 +308,7 @@ resource resDataCollectionRuleVMInsightsLock 'Microsoft.Authorization/locks@2020
   }
 }
 
-resource resDataCollectionRuleChangeTracking 'Microsoft.Insights/dataCollectionRules@2021-04-01' = {
+resource resDataCollectionRuleChangeTracking 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
   name: parDataCollectionRuleChangeTrackingName
   location: parLogAnalyticsWorkspaceLocation
   properties: {
@@ -579,7 +579,7 @@ resource resDataCollectionRuleChangeTrackingLock 'Microsoft.Authorization/locks@
   }
 }
 
-resource resDataCollectionRuleMDFCSQL'Microsoft.Insights/dataCollectionRules@2021-04-01' = {
+resource resDataCollectionRuleMDFCSQL'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
   name: parDataCollectionRuleMDFCSQLName
   location: parLogAnalyticsWorkspaceLocation
   properties: {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR includes a call to the `OnboardingStates` API for correctly onboarding Sentinel.
The simple deployment of the "SecurityInsights" solution is considered deprecated since July 1st. Source: https://techcommunity.microsoft.com/t5/microsoft-sentinel-blog/what-s-new-azure-sentinel-new-onboarding-offboarding-api/bc-p/3671438 and mail from MS linked in the issue #802.

*Why is the `SecurityInsights` solution still deployed and not removed?*

The `onboardingStates` API doesn't allow setting the SKU for Sentinel. Since this is an option within this template, I've left the deployment as is.
See the [comment from "laithhisham"](https://techcommunity.microsoft.com/t5/microsoft-sentinel-blog/what-s-new-azure-sentinel-new-onboarding-offboarding-api/bc-p/3671438/highlight/true#M3969). Quote:

> The OnboardingStates endpoint does not support managing the SKU directly, however you can still issue a call to the Microsoft.OperationsManagement/solutions to manage the SKU. The important point is that installing the solution on its own will no longer be considered a valid onboarding of a workspace to Sentinel, you will need to also issue a call to Microsoft.SecurityInsights/onboardingStates/default in order to complete the onboarding process. Otherwise, the calls to Sentinel's RP will fail.
> The deprecation will be of the legacy support of reaching Sentinel's RP after having only the solution installed and without defining the OnboardingStates. In that case you will start getting BadRequest (WorkspaceNotOnboarded).
> Hope this clarifies the change. 

I didn't updated the remaining API versions, because DCRs are failing to deploy with the latest version. Separate issue.

## Related Issues/Work Items

## This PR fixes/adds/changes/removes

Fixes #802
Closes #802 

### Breaking Changes

No breaking change.

## Testing Evidence
![CleanShot 2024-07-11 at 16 46 36@2x](https://github.com/Azure/ALZ-Bicep/assets/204027/34ea264f-864e-443d-a18a-069b98f83d82)


## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
