### PR TITLE
fix: General networking fixes and add active-active capability for vnet gateway

### DIFF
--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
@@ -537,12 +537,12 @@ module modBastionPublicIp '../publicIp/publicIp.bicep' = if (parAzBastionEnabled
   }
 }
 
-resource resBastionSubnetRef 'Microsoft.Network/virtualNetworks/subnets@2023-02-01' existing = if (parAzBastionEnabled) {
+resource resBastionSubnetRef 'Microsoft.Network/virtualNetworks/subnets@2024-01-01' existing = if (parAzBastionEnabled) {
   parent: resHubVnet
   name: 'AzureBastionSubnet'
 }
 
-resource resBastionNsg 'Microsoft.Network/networkSecurityGroups@2023-02-01' = if (parAzBastionEnabled) {
+resource resBastionNsg 'Microsoft.Network/networkSecurityGroups@2024-01-01' = if (parAzBastionEnabled) {
   name: parAzBastionNsgName
   location: parLocation
   tags: parTags
@@ -704,7 +704,7 @@ resource resBastionNsgLock 'Microsoft.Authorization/locks@2020-05-01' = if (parA
 // AzureBastionSubnet is required to deploy Bastion service. This subnet must exist in the parsubnets array if you enable Bastion Service.
 // There is a minimum subnet requirement of /27 prefix.
 // If you are deploying standard this needs to be larger. https://docs.microsoft.com/en-us/azure/bastion/configuration-settings#subnet
-resource resBastion 'Microsoft.Network/bastionHosts@2023-02-01' = if (parAzBastionEnabled) {
+resource resBastion 'Microsoft.Network/bastionHosts@2024-01-01' = if (parAzBastionEnabled) {
   location: parLocation
   name: parAzBastionName
   tags: parTags
@@ -740,7 +740,7 @@ resource resBastionLock 'Microsoft.Authorization/locks@2020-05-01' = if (parAzBa
   }
 }
 
-resource resGatewaySubnetRef 'Microsoft.Network/virtualNetworks/subnets@2023-02-01' existing = if (parVpnGatewayEnabled || parExpressRouteGatewayEnabled ) {
+resource resGatewaySubnetRef 'Microsoft.Network/virtualNetworks/subnets@2024-01-01' existing = if (parVpnGatewayEnabled || parExpressRouteGatewayEnabled ) {
   parent: resHubVnet
   name: 'GatewaySubnet'
 }
@@ -785,7 +785,7 @@ module modGatewayPublicIpActiveActive '../publicIp/publicIp.bicep' = [for (gatew
 }]
 
 //Minumum subnet size is /27 supporting documentation https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub
-resource resGateway 'Microsoft.Network/virtualNetworkGateways@2023-02-01' = [for (gateway, i) in varGwConfig: if ((gateway.name != 'noconfigVpn') && (gateway.name != 'noconfigEr')) {
+resource resGateway 'Microsoft.Network/virtualNetworkGateways@2024-01-01' = [for (gateway, i) in varGwConfig: if ((gateway.name != 'noconfigVpn') && (gateway.name != 'noconfigEr')) {
   name: gateway.name
   location: parLocation
   tags: parTags
@@ -860,12 +860,12 @@ resource resVirtualNetworkGatewayLock 'Microsoft.Authorization/locks@2020-05-01'
   }
 }]
 
-resource resAzureFirewallSubnetRef 'Microsoft.Network/virtualNetworks/subnets@2023-02-01' existing = if (parAzFirewallEnabled) {
+resource resAzureFirewallSubnetRef 'Microsoft.Network/virtualNetworks/subnets@2024-01-01' existing = if (parAzFirewallEnabled) {
   parent: resHubVnet
   name: 'AzureFirewallSubnet'
 }
 
-resource resAzureFirewallMgmtSubnetRef 'Microsoft.Network/virtualNetworks/subnets@2023-02-01' existing = if (parAzFirewallEnabled && (contains(map(parSubnets, subnets => subnets.name), 'AzureFirewallManagementSubnet'))) {
+resource resAzureFirewallMgmtSubnetRef 'Microsoft.Network/virtualNetworks/subnets@2024-01-01' existing = if (parAzFirewallEnabled && (contains(map(parSubnets, subnets => subnets.name), 'AzureFirewallManagementSubnet'))) {
   parent: resHubVnet
   name: 'AzureFirewallManagementSubnet'
 }
@@ -908,7 +908,7 @@ module modAzureFirewallMgmtPublicIp '../publicIp/publicIp.bicep' = if (parAzFire
   }
 }
 
-resource resFirewallPolicies 'Microsoft.Network/firewallPolicies@2023-02-01' = if (parAzFirewallEnabled && parAzFirewallPoliciesEnabled) {
+resource resFirewallPolicies 'Microsoft.Network/firewallPolicies@2024-01-01' = if (parAzFirewallEnabled && parAzFirewallPoliciesEnabled) {
   name: parAzFirewallPoliciesName
   location: parLocation
   tags: parTags
@@ -947,7 +947,7 @@ resource resFirewallPoliciesLock 'Microsoft.Authorization/locks@2020-05-01' = if
 
 // AzureFirewallSubnet is required to deploy Azure Firewall . This subnet must exist in the parsubnets array if you deploy.
 // There is a minimum subnet requirement of /26 prefix.
-resource resAzureFirewall 'Microsoft.Network/azureFirewalls@2023-02-01' = if (parAzFirewallEnabled) {
+resource resAzureFirewall 'Microsoft.Network/azureFirewalls@2024-01-01' = if (parAzFirewallEnabled) {
   dependsOn: [
     resGateway
   ]
@@ -1060,7 +1060,7 @@ resource resAzureFirewallLock 'Microsoft.Authorization/locks@2020-05-01' = if (p
 }
 
 //If Azure Firewall is enabled we will deploy a RouteTable to redirect Traffic to the Firewall.
-resource resHubRouteTable 'Microsoft.Network/routeTables@2023-02-01' = if (parAzFirewallEnabled) {
+resource resHubRouteTable 'Microsoft.Network/routeTables@2024-01-01' = if (parAzFirewallEnabled) {
   name: parHubRouteTableName
   location: parLocation
   tags: parTags

--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -618,7 +618,7 @@ output outVirtualHubId array = [for (hub, i) in parVirtualWanHubs: {
 }]
 
 // Output DDoS Plan ID
-output outDdosPlanResourceId string = resDdosProtectionPlan.id
+output outDdosPlanResourceId string = parDdosEnabled ? resDdosProtectionPlan.id : ''
 
 // Output Private DNS Zones
 output outPrivateDnsZones array = (parPrivateDnsZonesEnabled ? modPrivateDnsZones.outputs.outPrivateDnsZones : [])


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This pull request includes several updates to the `infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep` file to upgrade the API versions of various Azure resources and add support for active-active configurations for gateways.

### API Version Upgrades:
* Updated API versions for `resBastionSubnetRef`, `resBastionNsg`, `resBastion`, `resGatewaySubnetRef`, `resAzureFirewallSubnetRef`, `resAzureFirewallMgmtSubnetRef`, `resFirewallPolicies`, `resAzureFirewall`, and `resHubRouteTable` to `2024-01-01`. [[1]](diffhunk://#diff-6f15d7e8d605ac4753479b21282427b592dfde471ef345500fc2dbd050c2f422L540-R545) [[2]](diffhunk://#diff-6f15d7e8d605ac4753479b21282427b592dfde471ef345500fc2dbd050c2f422L707-R707) [[3]](diffhunk://#diff-6f15d7e8d605ac4753479b21282427b592dfde471ef345500fc2dbd050c2f422L743-R743) [[4]](diffhunk://#diff-6f15d7e8d605ac4753479b21282427b592dfde471ef345500fc2dbd050c2f422L823-R868) [[5]](diffhunk://#diff-6f15d7e8d605ac4753479b21282427b592dfde471ef345500fc2dbd050c2f422L871-R911) [[6]](diffhunk://#diff-6f15d7e8d605ac4753479b21282427b592dfde471ef345500fc2dbd050c2f422L910-R950) [[7]](diffhunk://#diff-6f15d7e8d605ac4753479b21282427b592dfde471ef345500fc2dbd050c2f422L1023-R1063)

### Gateway Configuration Enhancements:
* Added support for active-active gateway configurations by creating a second public IP if the gateway is active-active.
* Modified `ipConfigurations` to include a secondary IP configuration when `activeActive` is true.

### Conditional Outputs:
* Updated the `outDdosPlanResourceId` output to conditionally return an empty string if DDoS protection is not enabled.

## Related Issues/Work Items

Fixes #561
Fixes [AB#35815](https://dev.azure.com/CSUSolEng/2a9d5a5a-8998-4ad0-81c8-ef3045e4da97/_workitems/edit/35815)

## This PR fixes/adds/changes/removes

1. Adds the capability to support active-active virtual network gateway configuration
2. Fixes issues with parDDosId when parDDosEnabled is set to false.
3. Updates hub networking module api versions

### Breaking Changes

None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [x] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [x] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
