### PR TITLE
feat: updates to fix Region name now being appended to azFw policy name #914

### DIFF
--- a/infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md
+++ b/infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md
@@ -22,7 +22,7 @@ parVpnGatewayName | No       | VPN Gateway Name.
 parExpressRouteGatewayName | No       | ExpressRoute Gateway Name.
 parAzFirewallName | No       | Azure Firewall Name.
 parAzFirewallPolicyDeploymentStyle | No       | The deployment style of the Azure Firewall Policy. Either one shared firewall policy (`SharedGlobal`) or one policy per region (`PerRegion`), defaults to `SharedGlobal`.
-parAzFirewallPoliciesName | No       | Azure Firewall Policies Name.
+parAzFirewallPoliciesName | No       | Azure Firewall Policies Name. This is used to automatically generate a name for the Azure Firewall Policy following concat of the pattern `parAzFirewallPoliciesName-hub.parHubLocation` if you want to provide a true custom name then specify a value in each object in the array of `parVirtualWanHubs.parAzFirewallPolicyCustomName`.
 parAzFirewallPoliciesAutoLearn | No       | The operation mode for automatically learning private ranges to not be SNAT.
 parAzFirewallPoliciesPrivateRanges | No       | Private IP addresses/IP ranges to which traffic will not be SNAT.
 parAzureFirewallLock | No       | Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
@@ -205,7 +205,7 @@ The deployment style of the Azure Firewall Policy. Either one shared firewall po
 
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
 
-Azure Firewall Policies Name.
+Azure Firewall Policies Name. This is used to automatically generate a name for the Azure Firewall Policy following concat of the pattern `parAzFirewallPoliciesName-hub.parHubLocation` if you want to provide a true custom name then specify a value in each object in the array of `parVirtualWanHubs.parAzFirewallPolicyCustomName`.
 
 - Default value: `[format('{0}-azfwpolicy', parameters('parCompanyPrefix'))]`
 

--- a/infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md
+++ b/infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md
@@ -21,6 +21,7 @@ parVirtualWanHubsLock | No       | Resource Lock Configuration for Virtual WAN H
 parVpnGatewayName | No       | VPN Gateway Name.
 parExpressRouteGatewayName | No       | ExpressRoute Gateway Name.
 parAzFirewallName | No       | Azure Firewall Name.
+parAzFirewallPolicyDeploymentStyle | No       | The deployment style of the Azure Firewall Policy. Either one shared firewall policy (`SharedGlobal`) or one policy per region (`PerRegion`), defaults to `SharedGlobal`.
 parAzFirewallPoliciesName | No       | Azure Firewall Policies Name.
 parAzFirewallPoliciesAutoLearn | No       | The operation mode for automatically learning private ranges to not be SNAT.
 parAzFirewallPoliciesPrivateRanges | No       | Private IP addresses/IP ranges to which traffic will not be SNAT.
@@ -191,6 +192,14 @@ ExpressRoute Gateway Name.
 Azure Firewall Name.
 
 - Default value: `[format('{0}-fw', parameters('parCompanyPrefix'))]`
+
+### parAzFirewallPolicyDeploymentStyle
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+The deployment style of the Azure Firewall Policy. Either one shared firewall policy (`SharedGlobal`) or one policy per region (`PerRegion`), defaults to `SharedGlobal`.
+
+- Default value: `SharedGlobal`
 
 ### parAzFirewallPoliciesName
 
@@ -429,6 +438,9 @@ outAzFwPrivateIps | array |
         },
         "parAzFirewallName": {
             "value": "[format('{0}-fw', parameters('parCompanyPrefix'))]"
+        },
+        "parAzFirewallPolicyDeploymentStyle": {
+            "value": "SharedGlobal"
         },
         "parAzFirewallPoliciesName": {
             "value": "[format('{0}-azfwpolicy', parameters('parCompanyPrefix'))]"

--- a/infra-as-code/bicep/modules/vwanConnectivity/parameters/mc-vwanConnectivity.parameters.all.json
+++ b/infra-as-code/bicep/modules/vwanConnectivity/parameters/mc-vwanConnectivity.parameters.all.json
@@ -35,6 +35,9 @@
     "parAzFirewallPoliciesName": {
       "value": "alz-azfwpolicy"
     },
+    "parAzFirewallPolicyDeploymentStyle": {
+      "value": "SharedGlobal"
+    },
     "parVirtualWanHubs": {
       "value": [
         {

--- a/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.all.json
+++ b/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.all.json
@@ -32,6 +32,9 @@
     "parAzFirewallPoliciesName": {
       "value": "alz-azfwpolicy"
     },
+    "parAzFirewallPolicyDeploymentStyle": {
+      "value": "SharedGlobal"
+    },
     "parVirtualWanHubs": {
       "value": [
         {

--- a/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.multiRegion.all.json
+++ b/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.multiRegion.all.json
@@ -84,7 +84,7 @@
       "value": 1
     },
     "parDdosEnabled": {
-      "value": false
+      "value": true
     },
     "parDdosPlanName": {
       "value": "alz-ddos-plan"

--- a/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.multiRegion.all.json
+++ b/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.multiRegion.all.json
@@ -32,6 +32,9 @@
     "parAzFirewallPoliciesName": {
       "value": "alz-azfwpolicy"
     },
+    "parAzFirewallPolicyDeploymentStyle": {
+      "value": "PerRegion"
+    },
     "parVirtualWanHubs": {
       "value": [
         {

--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -193,7 +193,7 @@ param parAzFirewallName string = '${parCompanyPrefix}-fw'
 @sys.description('The deployment style of the Azure Firewall Policy. Either one shared firewall policy (`SharedGlobal`) or one policy per region (`PerRegion`), defaults to `SharedGlobal`.')
 param parAzFirewallPolicyDeploymentStyle azFirewallPolicyDeploymentStyleType = 'SharedGlobal'
 
-@sys.description('Azure Firewall Policies Name.')
+@sys.description('Azure Firewall Policies Name. This is used to automatically generate a name for the Azure Firewall Policy following concat of the pattern `parAzFirewallPoliciesName-hub.parHubLocation` if you want to provide a true custom name then specify a value in each object in the array of `parVirtualWanHubs.parAzFirewallPolicyCustomName`.')
 param parAzFirewallPoliciesName string = '${parCompanyPrefix}-azfwpolicy'
 
 @description('The operation mode for automatically learning private ranges to not be SNAT.')


### PR DESCRIPTION
This pull request introduces several changes to the `infra-as-code/bicep/modules/vwanConnectivity` module, primarily focusing on the addition of new parameters and the restructuring of resource definitions to support different deployment styles for Azure Firewall policies. The most important changes include the introduction of the `parAzFirewallPolicyDeploymentStyle` parameter, the addition of custom names for Azure Firewall policies via `parAzFirewallPolicyCustomName`, and the refactoring of resource definitions to support both shared global and per-region deployment styles.

## Why

This was needed to fix #914, but it also posed the question of how customers should deploy the Azure Firewall Policy in a multi region configuration, today the module would create a policy per region, but that may not be desired. Hence the module now supports, via this PR, the ability to chose between a `PerRegion` or `SharedGlobal` firewall policy deployment approach.

### New Parameters and Types:
* Added `parAzFirewallPolicyDeploymentStyle` parameter to specify the deployment style of Azure Firewall policies (`SharedGlobal` or `PerRegion`). [[1]](diffhunk://#diff-e29b1accf3bb652de2f382b327434584dbaab4f0ad9554694bc598623f4f6790R38-R40) [[2]](diffhunk://#diff-738d81e8ca299919f381069a16b389e5db8e96d4bedf70463ee3c2bf37ea841dR35-R37) [[3]](diffhunk://#diff-70de4741bd3e8a057e1b3559a955eae93d5fcfd4f0d65226f7e90c8ebbb79b11R35-R37) [[4]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdR193-R195)
* Introduced `azFirewallPolicyDeploymentStyleType` type to define the possible values for `parAzFirewallPolicyDeploymentStyle`.

### Custom Names for Policies:
* Added `parAzFirewallPolicyCustomName` parameter to allow specifying custom names for Azure Firewall policies.

### Resource Definitions Refactoring:
* Refactored resource definitions to support both shared global and per-region deployment styles for Azure Firewall policies. This includes the creation of new resources and locks based on the deployment style. [[1]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL433-R472) [[2]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL474-R575)
* Updated the `resVhub`, `resVhubLock`, `resVhubRouteTable`, `resVhubRoutingIntent`, `resVpnGateway`, `resVpnGatewayLock`, `resErGateway`, and `resErGatewayLock` resources to use a more consistent and readable array syntax. [[1]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL301-R317) [[2]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL316-R348) [[3]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL347-R391) [[4]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL379-R423) [[5]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL406-R460)

### Output Adjustments:
* Modified output definitions to use a more consistent and readable array syntax. [[1]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL539-R638) [[2]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL563-R659)

## Testing Evidence

### vwanConnectivity.bicep - defaults with VPN, DDOS & EX disabled (for speed)
![image](https://github.com/user-attachments/assets/adbb64b9-e4e4-4581-a820-0985a78c595a)

### vwanConnectivity.bicep - Multi Region Param with VPN, DDOS & EX disabled (for speed) - one hub with custom FW policy name
![image](https://github.com/user-attachments/assets/9cd33445-7d30-47df-8725-0e1515ab6a2f)

