### PR TITLE
refactor: Add gateway udt and add allowed values

### DIFF
--- a/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking-multiRegion.bicep.md
+++ b/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking-multiRegion.bicep.md
@@ -1,6 +1,6 @@
-# ALZ Bicep - Hub Networking Module
+# ALZ Bicep - Hub Networking Multi-Region Module
 
-ALZ Bicep Module used to set up Hub Networking
+ALZ Bicep Module used to set up Hub Networking in two regions.
 
 ## Parameters
 
@@ -11,14 +11,14 @@ parSecondaryLocation | Yes      | The secondary Azure Region to deploy the resou
 parCompanyPrefix | No       | Prefix value which will be prepended to all resource names.
 parHubNetworkName | No       | Name for Hub Network.
 parHubNetworkNameSecondaryLocation | No       | Name for Hub Network in the secondary location.
-parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parHubNetworkAddressPrefix | No       | The IP address range for Hub Network.
 parHubNetworkAddressPrefixSecondaryLocation | No       | The IP address range for Hub Network in the secondary location.
 parSubnets     | No       | The name, IP address range, network security group, route table and delegation serviceName for each subnet in the virtual networks.
 parSubnetsSecondaryLocation | No       | The name, IP address range, network security group, route table and delegation serviceName for each subnet in the virtual networks in the secondary location.
 parDnsServerIps | No       | Array of DNS Server IP addresses for VNet.
 parDnsServerIpsSecondaryLocation | No       | Array of DNS Server IP addresses for VNet in the secondary location.
-parVirtualNetworkLock | No       | Resource Lock Configuration for Virtual Network.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parVirtualNetworkLock | No       | Resource Lock Configuration for Virtual Network.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parPublicIpSku | No       | Public IP Address SKU.
 parPublicIpSkuSecondaryLocation | No       | Public IP Address SKU in secondary location.
 parPublicIpPrefix | No       | Optional Prefix for Public IPs. Include a succedent dash if required. Example: prefix-
@@ -34,12 +34,12 @@ parAzBastionTunneling | No       | Switch to enable/disable Bastion native clien
 parAzBastionTunnelingSecondaryLocation | No       | Switch to enable/disable Bastion native client support in secondary location. This is only supported when the Standard SKU is used for Bastion as documented here: https://learn.microsoft.com/azure/bastion/native-client
 parAzBastionNsgName | No       | Name for Azure Bastion Subnet NSG.
 parAzBastionNsgNameSecondaryLocation | No       | Name for Azure Bastion Subnet NSG in secondary location.
-parBastionLock | No       | Resource Lock Configuration for Bastion.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parBastionLock | No       | Resource Lock Configuration for Bastion.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parDdosEnabled | No       | Switch to enable/disable DDoS Network Protection deployment.
 parDdosEnabledSecondaryLocation | No       | Switch to enable/disable DDoS Network Protection deployment in the secondary location.
 parDdosPlanName | No       | DDoS Plan Name.
 parDdosPlanNameSecondaryLocation | No       | DDoS Plan Name in the secondary location.
-parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parAzFirewallEnabled | No       | Switch to enable/disable Azure Firewall deployment.
 parAzFirewallEnabledSecondaryLocation | No       | Switch to enable/disable Azure Firewall deployment in the secondary location.
 parAzFirewallName | No       | Azure Firewall Name.
@@ -68,18 +68,18 @@ parAzFirewallDnsProxyEnabled | No       | Switch to enable/disable Azure Firewal
 parAzFirewallDnsProxyEnabledSecondaryLocation | No       | Switch to enable/disable Azure Firewall DNS Proxy in the secndary location.
 parAzFirewallDnsServers | No       | Array of custom DNS servers used by Azure Firewall.
 parAzFirewallDnsServersSecondaryLocation | No       | Array of custom DNS servers used by Azure Firewall in the secondary location.
-parAzureFirewallLock | No       |  Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parAzureFirewallLock | No       |  Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parHubRouteTableName | No       | Name of Route table to create for the default route of Hub.
 parHubRouteTableNameSecondaryLocation | No       | Name of Route table to create for the default route of Hub in the secondary location.
 parDisableBgpRoutePropagation | No       | Switch to enable/disable BGP Propagation on route table.
 parDisableBgpRoutePropagationSecondaryLocation | No       | Switch to enable/disable BGP Propagation on route table in the secondary location.
-parHubRouteTableLock | No       | Resource Lock Configuration for Hub Route Table.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parHubRouteTableLock | No       | Resource Lock Configuration for Hub Route Table.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parPrivateDnsZonesEnabled | No       | Switch to enable/disable Private DNS Zones deployment.
 parPrivateDnsZonesResourceGroup | No       | Resource Group Name for Private DNS Zones.
 parPrivateDnsZones | No       | Array of DNS Zones to provision and link to Hub Virtual Networks. Default: All known Azure Private DNS Zones, baked into underlying AVM module see: https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones#parameter-privatelinkprivatednszones
 parVirtualNetworkIdToLinkFailover | No       | Resource ID of Failover VNet for Private DNS Zone VNet Failover Links
 parVirtualNetworkResourceIdsToLinkTo | No       | Array of Resource IDs of VNets to link to Private DNS Zones. Hub VNets are automatically included by module.
-parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parVpnGatewayEnabled | No       | Switch to enable/disable VPN virtual network gateway deployment.
 parVpnGatewayEnabledSecondaryLocation | No       | Switch to enable/disable VPN virtual network gateway deployment in secondary location.
 parVpnGatewayConfig | No       | Configuration for VPN virtual network gateway to be deployed.
@@ -88,7 +88,7 @@ parExpressRouteGatewayEnabled | No       | Switch to enable/disable ExpressRoute
 parExpressRouteGatewayEnabledSecondaryLocation | No       | Switch to enable/disable ExpressRoute virtual network gateway deployment in secondary location.
 parExpressRouteGatewayConfig | No       | Configuration for ExpressRoute virtual network gateway to be deployed.
 parExpressRouteGatewayConfigSecondaryLocation | No       | Configuration for ExpressRoute virtual network gateway to be deployed in secondary location.
-parVirtualNetworkGatewayLock | No       | Resource Lock Configuration for ExpressRoute Virtual Network Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parVirtualNetworkGatewayLock | No       | Resource Lock Configuration for ExpressRoute Virtual Network Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parTags        | No       | Tags you would like to be applied to all resources in this module.
 parTelemetryOptOut | No       | Set Parameter to true to Opt-out of deployment telemetry.
 parBastionOutboundSshRdpPorts | No       | Define outbound destination ports or ranges for SSH or RDP that you want to access from Azure Bastion.
@@ -735,7 +735,7 @@ Switch to enable/disable VPN virtual network gateway deployment in secondary loc
 
 Configuration for VPN virtual network gateway to be deployed.
 
-- Default value: `@{name=[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]; gatewayType=Vpn; sku=VpnGw1AZ; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
+- Default value: `@{name=[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]; gatewayType=Vpn; sku=ErGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
 
 ### parVpnGatewayConfigSecondaryLocation
 
@@ -743,7 +743,7 @@ Configuration for VPN virtual network gateway to be deployed.
 
 Configuration for VPN virtual network gateway to be deployed in secondary location.
 
-- Default value: `@{name=[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parSecondaryLocation'))]; gatewayType=Vpn; sku=VpnGw1AZ; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
+- Default value: `@{name=[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parSecondaryLocation'))]; gatewayType=Vpn; sku=VpnGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
 
 ### parExpressRouteGatewayEnabled
 
@@ -1160,7 +1160,7 @@ outBastionNsgNameSecondaryLocation | string |
             "value": {
                 "name": "[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]",
                 "gatewayType": "Vpn",
-                "sku": "VpnGw1AZ",
+                "sku": "ErGw1AZ",
                 "vpnType": "RouteBased",
                 "vpnGatewayGeneration": "Generation1",
                 "enableBgp": false,

--- a/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking-multiRegion.bicep.md
+++ b/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking-multiRegion.bicep.md
@@ -11,14 +11,14 @@ parSecondaryLocation | Yes      | The secondary Azure Region to deploy the resou
 parCompanyPrefix | No       | Prefix value which will be prepended to all resource names.
 parHubNetworkName | No       | Name for Hub Network.
 parHubNetworkNameSecondaryLocation | No       | Name for Hub Network in the secondary location.
-parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parHubNetworkAddressPrefix | No       | The IP address range for Hub Network.
 parHubNetworkAddressPrefixSecondaryLocation | No       | The IP address range for Hub Network in the secondary location.
 parSubnets     | No       | The name, IP address range, network security group, route table and delegation serviceName for each subnet in the virtual networks.
 parSubnetsSecondaryLocation | No       | The name, IP address range, network security group, route table and delegation serviceName for each subnet in the virtual networks in the secondary location.
 parDnsServerIps | No       | Array of DNS Server IP addresses for VNet.
 parDnsServerIpsSecondaryLocation | No       | Array of DNS Server IP addresses for VNet in the secondary location.
-parVirtualNetworkLock | No       | Resource Lock Configuration for Virtual Network.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parVirtualNetworkLock | No       | Resource Lock Configuration for Virtual Network.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parPublicIpSku | No       | Public IP Address SKU.
 parPublicIpSkuSecondaryLocation | No       | Public IP Address SKU in secondary location.
 parPublicIpPrefix | No       | Optional Prefix for Public IPs. Include a succedent dash if required. Example: prefix-
@@ -34,12 +34,12 @@ parAzBastionTunneling | No       | Switch to enable/disable Bastion native clien
 parAzBastionTunnelingSecondaryLocation | No       | Switch to enable/disable Bastion native client support in secondary location. This is only supported when the Standard SKU is used for Bastion as documented here: https://learn.microsoft.com/azure/bastion/native-client
 parAzBastionNsgName | No       | Name for Azure Bastion Subnet NSG.
 parAzBastionNsgNameSecondaryLocation | No       | Name for Azure Bastion Subnet NSG in secondary location.
-parBastionLock | No       | Resource Lock Configuration for Bastion.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parBastionLock | No       | Resource Lock Configuration for Bastion.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parDdosEnabled | No       | Switch to enable/disable DDoS Network Protection deployment.
 parDdosEnabledSecondaryLocation | No       | Switch to enable/disable DDoS Network Protection deployment in the secondary location.
 parDdosPlanName | No       | DDoS Plan Name.
 parDdosPlanNameSecondaryLocation | No       | DDoS Plan Name in the secondary location.
-parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parAzFirewallEnabled | No       | Switch to enable/disable Azure Firewall deployment.
 parAzFirewallEnabledSecondaryLocation | No       | Switch to enable/disable Azure Firewall deployment in the secondary location.
 parAzFirewallName | No       | Azure Firewall Name.
@@ -68,18 +68,18 @@ parAzFirewallDnsProxyEnabled | No       | Switch to enable/disable Azure Firewal
 parAzFirewallDnsProxyEnabledSecondaryLocation | No       | Switch to enable/disable Azure Firewall DNS Proxy in the secndary location.
 parAzFirewallDnsServers | No       | Array of custom DNS servers used by Azure Firewall.
 parAzFirewallDnsServersSecondaryLocation | No       | Array of custom DNS servers used by Azure Firewall in the secondary location.
-parAzureFirewallLock | No       |  Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parAzureFirewallLock | No       |  Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parHubRouteTableName | No       | Name of Route table to create for the default route of Hub.
 parHubRouteTableNameSecondaryLocation | No       | Name of Route table to create for the default route of Hub in the secondary location.
 parDisableBgpRoutePropagation | No       | Switch to enable/disable BGP Propagation on route table.
 parDisableBgpRoutePropagationSecondaryLocation | No       | Switch to enable/disable BGP Propagation on route table in the secondary location.
-parHubRouteTableLock | No       | Resource Lock Configuration for Hub Route Table.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parHubRouteTableLock | No       | Resource Lock Configuration for Hub Route Table.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parPrivateDnsZonesEnabled | No       | Switch to enable/disable Private DNS Zones deployment.
 parPrivateDnsZonesResourceGroup | No       | Resource Group Name for Private DNS Zones.
 parPrivateDnsZones | No       | Array of DNS Zones to provision and link to Hub Virtual Networks. Default: All known Azure Private DNS Zones, baked into underlying AVM module see: https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones#parameter-privatelinkprivatednszones
 parVirtualNetworkIdToLinkFailover | No       | Resource ID of Failover VNet for Private DNS Zone VNet Failover Links
 parVirtualNetworkResourceIdsToLinkTo | No       | Array of Resource IDs of VNets to link to Private DNS Zones. Hub VNets are automatically included by module.
-parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parVpnGatewayEnabled | No       | Switch to enable/disable VPN virtual network gateway deployment.
 parVpnGatewayEnabledSecondaryLocation | No       | Switch to enable/disable VPN virtual network gateway deployment in secondary location.
 parVpnGatewayConfig | No       | Configuration for VPN virtual network gateway to be deployed.
@@ -88,7 +88,7 @@ parExpressRouteGatewayEnabled | No       | Switch to enable/disable ExpressRoute
 parExpressRouteGatewayEnabledSecondaryLocation | No       | Switch to enable/disable ExpressRoute virtual network gateway deployment in secondary location.
 parExpressRouteGatewayConfig | No       | Configuration for ExpressRoute virtual network gateway to be deployed.
 parExpressRouteGatewayConfigSecondaryLocation | No       | Configuration for ExpressRoute virtual network gateway to be deployed in secondary location.
-parVirtualNetworkGatewayLock | No       | Resource Lock Configuration for ExpressRoute Virtual Network Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parVirtualNetworkGatewayLock | No       | Resource Lock Configuration for ExpressRoute Virtual Network Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parTags        | No       | Tags you would like to be applied to all resources in this module.
 parTelemetryOptOut | No       | Set Parameter to true to Opt-out of deployment telemetry.
 parBastionOutboundSshRdpPorts | No       | Define outbound destination ports or ranges for SSH or RDP that you want to access from Azure Bastion.
@@ -735,7 +735,7 @@ Switch to enable/disable VPN virtual network gateway deployment in secondary loc
 
 Configuration for VPN virtual network gateway to be deployed.
 
-- Default value: `@{name=[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]; gatewayType=Vpn; sku=VpnGw1; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpsettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
+- Default value: `@{name=[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]; gatewayType=Vpn; sku=VpnGw1AZ; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
 
 ### parVpnGatewayConfigSecondaryLocation
 
@@ -743,7 +743,7 @@ Configuration for VPN virtual network gateway to be deployed.
 
 Configuration for VPN virtual network gateway to be deployed in secondary location.
 
-- Default value: `@{name=[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parSecondaryLocation'))]; gatewayType=Vpn; sku=VpnGw1; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpsettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
+- Default value: `@{name=[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parSecondaryLocation'))]; gatewayType=Vpn; sku=VpnGw1AZ; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
 
 ### parExpressRouteGatewayEnabled
 
@@ -767,7 +767,7 @@ Switch to enable/disable ExpressRoute virtual network gateway deployment in seco
 
 Configuration for ExpressRoute virtual network gateway to be deployed.
 
-- Default value: `@{name=[format('{0}-ExpressRoute-Gateway', parameters('parCompanyPrefix'))]; gatewayType=ExpressRoute; sku=ErGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=None; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpsettings=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
+- Default value: `@{name=[format('{0}-ExpressRoute-Gateway', parameters('parCompanyPrefix'))]; gatewayType=ExpressRoute; sku=ErGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=None; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
 
 ### parExpressRouteGatewayConfigSecondaryLocation
 
@@ -775,7 +775,7 @@ Configuration for ExpressRoute virtual network gateway to be deployed.
 
 Configuration for ExpressRoute virtual network gateway to be deployed in secondary location.
 
-- Default value: `@{name=[format('{0}-ExpressRoute-Gateway', parameters('parCompanyPrefix'))]; gatewayType=ExpressRoute; sku=ErGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=None; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpsettings=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
+- Default value: `@{name=[format('{0}-ExpressRoute-Gateway', parameters('parCompanyPrefix'))]; gatewayType=ExpressRoute; sku=ErGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=None; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
 
 ### parVirtualNetworkGatewayLock
 
@@ -1160,15 +1160,15 @@ outBastionNsgNameSecondaryLocation | string |
             "value": {
                 "name": "[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]",
                 "gatewayType": "Vpn",
-                "sku": "VpnGw1",
+                "sku": "VpnGw1AZ",
                 "vpnType": "RouteBased",
-                "generation": "Generation1",
+                "vpnGatewayGeneration": "Generation1",
                 "enableBgp": false,
                 "activeActive": false,
                 "enableBgpRouteTranslationForNat": false,
                 "enableDnsForwarding": false,
                 "bgpPeeringAddress": "",
-                "bgpsettings": {
+                "bgpSettings": {
                     "asn": 65515,
                     "bgpPeeringAddress": "",
                     "peerWeight": 5
@@ -1182,15 +1182,15 @@ outBastionNsgNameSecondaryLocation | string |
             "value": {
                 "name": "[format('{0}-Vpn-Gateway-{1}', parameters('parCompanyPrefix'), parameters('parSecondaryLocation'))]",
                 "gatewayType": "Vpn",
-                "sku": "VpnGw1",
+                "sku": "VpnGw1AZ",
                 "vpnType": "RouteBased",
-                "generation": "Generation1",
+                "vpnGatewayGeneration": "Generation1",
                 "enableBgp": false,
                 "activeActive": false,
                 "enableBgpRouteTranslationForNat": false,
                 "enableDnsForwarding": false,
                 "bgpPeeringAddress": "",
-                "bgpsettings": {
+                "bgpSettings": {
                     "asn": 65515,
                     "bgpPeeringAddress": "",
                     "peerWeight": 5
@@ -1218,10 +1218,10 @@ outBastionNsgNameSecondaryLocation | string |
                 "enableBgpRouteTranslationForNat": false,
                 "enableDnsForwarding": false,
                 "bgpPeeringAddress": "",
-                "bgpsettings": {
-                    "asn": "65515",
+                "bgpSettings": {
+                    "asn": 65515,
                     "bgpPeeringAddress": "",
-                    "peerWeight": "5"
+                    "peerWeight": 5
                 },
                 "ipConfigurationName": "vnetGatewayConfig",
                 "ipConfigurationActiveActiveName": "vnetGatewayConfig2"
@@ -1239,10 +1239,10 @@ outBastionNsgNameSecondaryLocation | string |
                 "enableBgpRouteTranslationForNat": false,
                 "enableDnsForwarding": false,
                 "bgpPeeringAddress": "",
-                "bgpsettings": {
-                    "asn": "65515",
+                "bgpSettings": {
+                    "asn": 65515,
                     "bgpPeeringAddress": "",
-                    "peerWeight": "5"
+                    "peerWeight": 5
                 },
                 "ipConfigurationName": "vnetGatewayConfig",
                 "ipConfigurationActiveActiveName": "vnetGatewayConfig2"

--- a/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
+++ b/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
@@ -9,11 +9,11 @@ Parameter name | Required | Description
 parLocation    | No       | The Azure Region to deploy the resources into.
 parCompanyPrefix | No       | Prefix value which will be prepended to all resource names.
 parHubNetworkName | No       | Name for Hub Network.
-parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parHubNetworkAddressPrefix | No       | The IP address range for Hub Network.
 parSubnets     | No       | The name, IP address range, network security group, route table and delegation serviceName for each subnet in the virtual networks.
 parDnsServerIps | No       | Array of DNS Server IP addresses for VNet.
-parVirtualNetworkLock | No       | Resource Lock Configuration for Virtual Network.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parVirtualNetworkLock | No       | Resource Lock Configuration for Virtual Network.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parPublicIpSku | No       | Public IP Address SKU.
 parPublicIpPrefix | No       | Optional Prefix for Public IPs. Include a succedent dash if required. Example: prefix-
 parPublicIpSuffix | No       | Optional Suffix for Public IPs. Include a preceding dash if required. Example: -suffix
@@ -22,10 +22,10 @@ parAzBastionName | No       | Name Associated with Bastion Service.
 parAzBastionSku | No       | Azure Bastion SKU.
 parAzBastionTunneling | No       | Switch to enable/disable Bastion native client support. This is only supported when the Standard SKU is used for Bastion as documented here: https://learn.microsoft.com/azure/bastion/native-client
 parAzBastionNsgName | No       | Name for Azure Bastion Subnet NSG.
-parBastionLock | No       | Resource Lock Configuration for Bastion.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parBastionLock | No       | Resource Lock Configuration for Bastion.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parDdosEnabled | No       | Switch to enable/disable DDoS Network Protection deployment.
 parDdosPlanName | No       | DDoS Plan Name.
-parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parAzFirewallEnabled | No       | Switch to enable/disable Azure Firewall deployment.
 parAzFirewallName | No       | Azure Firewall Name.
 parAzFirewallPoliciesEnabled | No       | Set this to true for the initial deployment as one firewall policy is required. Set this to false in subsequent deployments if using custom policies.
@@ -40,21 +40,21 @@ parAzErGatewayAvailabilityZones | No       | Availability Zones to deploy the VP
 parAzVpnGatewayAvailabilityZones | No       | Availability Zones to deploy the VPN/ER PIP across. Region must support Availability Zones to use. If it does not then leave empty. Ensure that you select a zonal SKU for the ER/VPN Gateway if using Availability Zones for the PIP.
 parAzFirewallDnsProxyEnabled | No       | Switch to enable/disable Azure Firewall DNS Proxy.
 parAzFirewallDnsServers | No       | Array of custom DNS servers used by Azure Firewall
-parAzureFirewallLock | No       |  Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parAzureFirewallLock | No       |  Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parHubRouteTableName | No       | Name of Route table to create for the default route of Hub.
 parDisableBgpRoutePropagation | No       | Switch to enable/disable BGP Propagation on route table.
-parHubRouteTableLock | No       | Resource Lock Configuration for Hub Route Table.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parHubRouteTableLock | No       | Resource Lock Configuration for Hub Route Table.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parPrivateDnsZonesEnabled | No       | Switch to enable/disable Private DNS Zones deployment.
 parPrivateDnsZonesResourceGroup | No       | Resource Group Name for Private DNS Zones.
 parPrivateDnsZones | No       | Array of DNS Zones to provision and link to  Hub Virtual Network. Default: All known Azure Private DNS Zones, baked into underlying AVM module see: https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones#parameter-privatelinkprivatednszones
 parVirtualNetworkIdToLinkFailover | No       | Resource ID of Failover VNet for Private DNS Zone VNet Failover Links
 parVirtualNetworkResourceIdsToLinkTo | No       | Array of Resource IDs of VNets to link to Private DNS Zones. Hub VNet is automatically included by module.
-parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parVpnGatewayEnabled | No       | Switch to enable/disable VPN virtual network gateway deployment.
 parVpnGatewayConfig | No       | Configuration for VPN virtual network gateway to be deployed.
 parExpressRouteGatewayEnabled | No       | Switch to enable/disable ExpressRoute virtual network gateway deployment.
 parExpressRouteGatewayConfig | No       | Configuration for ExpressRoute virtual network gateway to be deployed.
-parVirtualNetworkGatewayLock | No       | Resource Lock Configuration for ExpressRoute Virtual Network Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parVirtualNetworkGatewayLock | No       | Resource Lock Configuration for ExpressRoute Virtual Network Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 parTags        | No       | Tags you would like to be applied to all resources in this module.
 parTelemetryOptOut | No       | Set Parameter to true to Opt-out of deployment telemetry.
 parBastionOutboundSshRdpPorts | No       | Define outbound destination ports or ranges for SSH or RDP that you want to access from Azure Bastion.
@@ -454,7 +454,7 @@ Switch to enable/disable VPN virtual network gateway deployment.
 
 Configuration for VPN virtual network gateway to be deployed.
 
-- Default value: `@{name=[format('{0}-Vpn-Gateway', parameters('parCompanyPrefix'))]; gatewayType=Vpn; sku=VpnGw1AZ; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
+- Default value: `@{name=[format('{0}-Vpn-Gateway', parameters('parCompanyPrefix'))]; gatewayType=Vpn; sku=VpnGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
 
 ### parExpressRouteGatewayEnabled
 

--- a/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
+++ b/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking.bicep.md
@@ -9,11 +9,11 @@ Parameter name | Required | Description
 parLocation    | No       | The Azure Region to deploy the resources into.
 parCompanyPrefix | No       | Prefix value which will be prepended to all resource names.
 parHubNetworkName | No       | Name for Hub Network.
-parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parHubNetworkAddressPrefix | No       | The IP address range for Hub Network.
 parSubnets     | No       | The name, IP address range, network security group, route table and delegation serviceName for each subnet in the virtual networks.
 parDnsServerIps | No       | Array of DNS Server IP addresses for VNet.
-parVirtualNetworkLock | No       | Resource Lock Configuration for Virtual Network.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parVirtualNetworkLock | No       | Resource Lock Configuration for Virtual Network.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parPublicIpSku | No       | Public IP Address SKU.
 parPublicIpPrefix | No       | Optional Prefix for Public IPs. Include a succedent dash if required. Example: prefix-
 parPublicIpSuffix | No       | Optional Suffix for Public IPs. Include a preceding dash if required. Example: -suffix
@@ -22,10 +22,10 @@ parAzBastionName | No       | Name Associated with Bastion Service.
 parAzBastionSku | No       | Azure Bastion SKU.
 parAzBastionTunneling | No       | Switch to enable/disable Bastion native client support. This is only supported when the Standard SKU is used for Bastion as documented here: https://learn.microsoft.com/azure/bastion/native-client
 parAzBastionNsgName | No       | Name for Azure Bastion Subnet NSG.
-parBastionLock | No       | Resource Lock Configuration for Bastion.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parBastionLock | No       | Resource Lock Configuration for Bastion.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parDdosEnabled | No       | Switch to enable/disable DDoS Network Protection deployment.
 parDdosPlanName | No       | DDoS Plan Name.
-parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parAzFirewallEnabled | No       | Switch to enable/disable Azure Firewall deployment.
 parAzFirewallName | No       | Azure Firewall Name.
 parAzFirewallPoliciesEnabled | No       | Set this to true for the initial deployment as one firewall policy is required. Set this to false in subsequent deployments if using custom policies.
@@ -40,21 +40,21 @@ parAzErGatewayAvailabilityZones | No       | Availability Zones to deploy the VP
 parAzVpnGatewayAvailabilityZones | No       | Availability Zones to deploy the VPN/ER PIP across. Region must support Availability Zones to use. If it does not then leave empty. Ensure that you select a zonal SKU for the ER/VPN Gateway if using Availability Zones for the PIP.
 parAzFirewallDnsProxyEnabled | No       | Switch to enable/disable Azure Firewall DNS Proxy.
 parAzFirewallDnsServers | No       | Array of custom DNS servers used by Azure Firewall
-parAzureFirewallLock | No       |  Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parAzureFirewallLock | No       |  Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parHubRouteTableName | No       | Name of Route table to create for the default route of Hub.
 parDisableBgpRoutePropagation | No       | Switch to enable/disable BGP Propagation on route table.
-parHubRouteTableLock | No       | Resource Lock Configuration for Hub Route Table.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parHubRouteTableLock | No       | Resource Lock Configuration for Hub Route Table.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parPrivateDnsZonesEnabled | No       | Switch to enable/disable Private DNS Zones deployment.
 parPrivateDnsZonesResourceGroup | No       | Resource Group Name for Private DNS Zones.
 parPrivateDnsZones | No       | Array of DNS Zones to provision and link to  Hub Virtual Network. Default: All known Azure Private DNS Zones, baked into underlying AVM module see: https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones#parameter-privatelinkprivatednszones
 parVirtualNetworkIdToLinkFailover | No       | Resource ID of Failover VNet for Private DNS Zone VNet Failover Links
 parVirtualNetworkResourceIdsToLinkTo | No       | Array of Resource IDs of VNets to link to Private DNS Zones. Hub VNet is automatically included by module.
-parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parVpnGatewayEnabled | No       | Switch to enable/disable VPN virtual network gateway deployment.
 parVpnGatewayConfig | No       | Configuration for VPN virtual network gateway to be deployed.
 parExpressRouteGatewayEnabled | No       | Switch to enable/disable ExpressRoute virtual network gateway deployment.
 parExpressRouteGatewayConfig | No       | Configuration for ExpressRoute virtual network gateway to be deployed.
-parVirtualNetworkGatewayLock | No       | Resource Lock Configuration for ExpressRoute Virtual Network Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parVirtualNetworkGatewayLock | No       | Resource Lock Configuration for ExpressRoute Virtual Network Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parTags        | No       | Tags you would like to be applied to all resources in this module.
 parTelemetryOptOut | No       | Set Parameter to true to Opt-out of deployment telemetry.
 parBastionOutboundSshRdpPorts | No       | Define outbound destination ports or ranges for SSH or RDP that you want to access from Azure Bastion.
@@ -454,7 +454,7 @@ Switch to enable/disable VPN virtual network gateway deployment.
 
 Configuration for VPN virtual network gateway to be deployed.
 
-- Default value: `@{name=[format('{0}-Vpn-Gateway', parameters('parCompanyPrefix'))]; gatewayType=Vpn; sku=VpnGw1; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpsettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
+- Default value: `@{name=[format('{0}-Vpn-Gateway', parameters('parCompanyPrefix'))]; gatewayType=Vpn; sku=VpnGw1AZ; vpnType=RouteBased; generation=Generation1; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; vpnClientConfiguration=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
 
 ### parExpressRouteGatewayEnabled
 
@@ -470,7 +470,7 @@ Switch to enable/disable ExpressRoute virtual network gateway deployment.
 
 Configuration for ExpressRoute virtual network gateway to be deployed.
 
-- Default value: `@{name=[format('{0}-ExpressRoute-Gateway', parameters('parCompanyPrefix'))]; gatewayType=ExpressRoute; sku=ErGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=None; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpsettings=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
+- Default value: `@{name=[format('{0}-ExpressRoute-Gateway', parameters('parCompanyPrefix'))]; gatewayType=ExpressRoute; sku=ErGw1AZ; vpnType=RouteBased; vpnGatewayGeneration=None; enableBgp=False; activeActive=False; enableBgpRouteTranslationForNat=False; enableDnsForwarding=False; bgpPeeringAddress=; bgpSettings=; ipConfigurationName=vnetGatewayConfig; ipConfigurationActiveActiveName=vnetGatewayConfig2}`
 
 ### parVirtualNetworkGatewayLock
 
@@ -720,15 +720,15 @@ outBastionNsgName | string |
             "value": {
                 "name": "[format('{0}-Vpn-Gateway', parameters('parCompanyPrefix'))]",
                 "gatewayType": "Vpn",
-                "sku": "VpnGw1",
+                "sku": "VpnGw1AZ",
                 "vpnType": "RouteBased",
-                "generation": "Generation1",
+                "vpnGatewayGeneration": "Generation1",
                 "enableBgp": false,
                 "activeActive": false,
                 "enableBgpRouteTranslationForNat": false,
                 "enableDnsForwarding": false,
                 "bgpPeeringAddress": "",
-                "bgpsettings": {
+                "bgpSettings": {
                     "asn": 65515,
                     "bgpPeeringAddress": "",
                     "peerWeight": 5
@@ -753,10 +753,10 @@ outBastionNsgName | string |
                 "enableBgpRouteTranslationForNat": false,
                 "enableDnsForwarding": false,
                 "bgpPeeringAddress": "",
-                "bgpsettings": {
-                    "asn": "65515",
+                "bgpSettings": {
+                    "asn": 65515,
                     "bgpPeeringAddress": "",
-                    "peerWeight": "5"
+                    "peerWeight": 5
                 },
                 "ipConfigurationName": "vnetGatewayConfig",
                 "ipConfigurationActiveActiveName": "vnetGatewayConfig2"

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep
@@ -26,7 +26,7 @@ type virtualNetworkGatewayOptionsType = {
   gatewayType: ('Vpn' | 'ExpressRoute')
 
   @description('SKU of the gateway.')
-  sku: ('Basic' | 'VpnGw1AZAZ' | 'VpnGw2AZ' | 'VpnGw3AZ' | 'VpnGw4AZ' | 'VpnGw5AZ' | 'ErGw1AZ' | 'ErGw2AZ' | 'ErGw3AZ' | 'ErGwScale' | 'HighPerformance' | 'Standard' | 'UltraPerformance')
+  sku: ('Basic' | 'VpnGw1AZ' | 'VpnGw2AZ' | 'VpnGw3AZ' | 'VpnGw4AZ' | 'VpnGw5AZ' | 'ErGw1AZ' | 'ErGw2AZ' | 'ErGw3AZ' | 'ErGwScale' | 'HighPerformance' | 'Standard' | 'UltraPerformance')
 
   @description('Type of VPN.')
   vpnType: string
@@ -518,7 +518,7 @@ param parVpnGatewayConfig virtualNetworkGatewayOptionsType = {
 param parVpnGatewayConfigSecondaryLocation virtualNetworkGatewayOptionsType = {
   name: '${parCompanyPrefix}-Vpn-Gateway-${parSecondaryLocation}'
   gatewayType: 'Vpn'
-  sku: 'VpnGw1AZAZ'
+  sku: 'VpnGw1AZ'
   vpnType: 'RouteBased'
   vpnGatewayGeneration: 'Generation1'
   enableBgp: false

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep
@@ -1,5 +1,5 @@
-metadata name = 'ALZ Bicep - Hub Networking Module'
-metadata description = 'ALZ Bicep Module used to set up Hub Networking'
+metadata name = 'ALZ Bicep - Hub Networking Multi-Region Module'
+metadata description = 'ALZ Bicep Module used to set up Hub Networking in two regions.'
 
 type subnetOptionsType = ({
   @description('Name of subnet.')
@@ -17,6 +17,61 @@ type subnetOptionsType = ({
   @description('Name of the delegation to create for the subnet.')
   delegation: string?
 })[]
+
+type virtualNetworkGatewayOptionsType = {
+  @description('Name of the gateway.')
+  name: string
+
+  @description('Type of gateway.')
+  gatewayType: ('Vpn' | 'ExpressRoute')
+
+  @description('SKU of the gateway.')
+  sku: ('Basic' | 'VpnGw1AZAZ' | 'VpnGw2AZ' | 'VpnGw3AZ' | 'VpnGw4AZ' | 'VpnGw5AZ' | 'ErGw1AZ' | 'ErGw2AZ' | 'ErGw3AZ' | 'ErGwScale' | 'HighPerformance' | 'Standard' | 'UltraPerformance')
+
+  @description('Type of VPN.')
+  vpnType: string
+
+  @description('Generation of the VPN Gateway.')
+  vpnGatewayGeneration: ('Generation1' | 'Generation2' | 'None' )
+
+  @description('Enable BGP on the gateway.')
+  enableBgp: bool
+
+  @description('Enable Active-Active on the gateway.')
+  activeActive: bool
+
+  @description('Enable BGP Route Translation for NAT on the gateway.')
+  enableBgpRouteTranslationForNat: bool
+
+  @description('Enable DNS Forwarding on the gateway.')
+  enableDnsForwarding: bool
+
+  @description('BGP Peering Address for the gateway.')
+  bgpPeeringAddress: string?
+
+  @description('BGP Settings for the gateway.')
+  bgpSettings: {
+    @minValue(0)
+    @maxValue(4294967295)
+    @description('ASN for the gateway.')
+    asn: int
+
+    @description('BGP Peering Address for the gateway.')
+    bgpPeeringAddress: string?
+
+    @description('Peer Weight for the gateway.')
+    peerWeight: int
+  }
+
+  @description('VPN Client Configuration for the gateway.')
+  vpnClientConfiguration: object?
+
+  @description('Name of the IP Configuration for the gateway.')
+  ipConfigurationName: string
+
+  @description('Name of the Active-Active IP Configuration for the gateway.')
+  ipConfigurationActiveActiveName: string
+}
 
 type lockType = {
   @description('Optional. Specify the name of lock.')
@@ -437,18 +492,18 @@ param parVpnGatewayEnabledSecondaryLocation bool = true
 
 //ASN must be 65515 if deploying VPN & ER for co-existence to work: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-howto-coexist-resource-manager#limits-and-limitations
 @sys.description('Configuration for VPN virtual network gateway to be deployed.')
-param parVpnGatewayConfig object = {
+param parVpnGatewayConfig virtualNetworkGatewayOptionsType = {
   name: '${parCompanyPrefix}-Vpn-Gateway-${parLocation}'
   gatewayType: 'Vpn'
-  sku: 'VpnGw1'
+  sku: 'ErGw1AZ'
   vpnType: 'RouteBased'
-  generation: 'Generation1'
+  vpnGatewayGeneration: 'Generation1'
   enableBgp: false
   activeActive: false
   enableBgpRouteTranslationForNat: false
   enableDnsForwarding: false
   bgpPeeringAddress: ''
-  bgpsettings: {
+  bgpSettings: {
     asn: 65515
     bgpPeeringAddress: ''
     peerWeight: 5
@@ -460,18 +515,18 @@ param parVpnGatewayConfig object = {
 
 //ASN must be 65515 if deploying VPN & ER for co-existence to work: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-howto-coexist-resource-manager#limits-and-limitations
 @sys.description('Configuration for VPN virtual network gateway to be deployed in secondary location.')
-param parVpnGatewayConfigSecondaryLocation object = {
+param parVpnGatewayConfigSecondaryLocation virtualNetworkGatewayOptionsType = {
   name: '${parCompanyPrefix}-Vpn-Gateway-${parSecondaryLocation}'
   gatewayType: 'Vpn'
-  sku: 'VpnGw1'
+  sku: 'VpnGw1AZAZ'
   vpnType: 'RouteBased'
-  generation: 'Generation1'
+  vpnGatewayGeneration: 'Generation1'
   enableBgp: false
   activeActive: false
   enableBgpRouteTranslationForNat: false
   enableDnsForwarding: false
   bgpPeeringAddress: ''
-  bgpsettings: {
+  bgpSettings: {
     asn: 65515
     bgpPeeringAddress: ''
     peerWeight: 5
@@ -488,7 +543,7 @@ param parExpressRouteGatewayEnabled bool = true
 param parExpressRouteGatewayEnabledSecondaryLocation bool = true
 
 @sys.description('Configuration for ExpressRoute virtual network gateway to be deployed.')
-param parExpressRouteGatewayConfig object = {
+param parExpressRouteGatewayConfig virtualNetworkGatewayOptionsType = {
   name: '${parCompanyPrefix}-ExpressRoute-Gateway'
   gatewayType: 'ExpressRoute'
   sku: 'ErGw1AZ'
@@ -499,17 +554,17 @@ param parExpressRouteGatewayConfig object = {
   enableBgpRouteTranslationForNat: false
   enableDnsForwarding: false
   bgpPeeringAddress: ''
-  bgpsettings: {
-    asn: '65515'
+  bgpSettings: {
+    asn: 65515
     bgpPeeringAddress: ''
-    peerWeight: '5'
+    peerWeight: 5
   }
   ipConfigurationName: 'vnetGatewayConfig'
   ipConfigurationActiveActiveName: 'vnetGatewayConfig2'
 }
 
 @sys.description('Configuration for ExpressRoute virtual network gateway to be deployed in secondary location.')
-param parExpressRouteGatewayConfigSecondaryLocation object = {
+param parExpressRouteGatewayConfigSecondaryLocation virtualNetworkGatewayOptionsType = {
   name: '${parCompanyPrefix}-ExpressRoute-Gateway'
   gatewayType: 'ExpressRoute'
   sku: 'ErGw1AZ'
@@ -520,10 +575,10 @@ param parExpressRouteGatewayConfigSecondaryLocation object = {
   enableBgpRouteTranslationForNat: false
   enableDnsForwarding: false
   bgpPeeringAddress: ''
-  bgpsettings: {
-    asn: '65515'
+  bgpSettings: {
+    asn: 65515
     bgpPeeringAddress: ''
-    peerWeight: '5'
+    peerWeight: 5
   }
   ipConfigurationName: 'vnetGatewayConfig'
   ipConfigurationActiveActiveName: 'vnetGatewayConfig2'
@@ -1406,7 +1461,7 @@ resource resGateway 'Microsoft.Network/virtualNetworkGateways@2024-01-01' = [
       enableDnsForwarding: gateway.enableDnsForwarding
       bgpSettings: (gateway.enableBgp) ? gateway.bgpSettings : null
       gatewayType: gateway.gatewayType
-      vpnGatewayGeneration: (toLower(gateway.gatewayType) == 'vpn') ? gateway.generation : 'None'
+      vpnGatewayGeneration: (toLower(gateway.gatewayType) == 'vpn') ? gateway.vpnGatewayGeneration : 'None'
       vpnType: gateway.vpnType
       sku: {
         name: gateway.sku
@@ -1476,7 +1531,7 @@ resource resGatewaySecondaryLocation 'Microsoft.Network/virtualNetworkGateways@2
       enableDnsForwarding: gateway.enableDnsForwarding
       bgpSettings: (gateway.enableBgp) ? gateway.bgpSettings : null
       gatewayType: gateway.gatewayType
-      vpnGatewayGeneration: (toLower(gateway.gatewayType) == 'vpn') ? gateway.generation : 'None'
+      vpnGatewayGeneration: (toLower(gateway.gatewayType) == 'vpn') ? gateway.vpnGatewayGeneration : 'None'
       vpnType: gateway.vpnType
       sku: {
         name: gateway.sku

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
@@ -18,6 +18,61 @@ type subnetOptionsType = ({
   delegation: string?
 })[]
 
+type virtualNetworkGatewayOptionsType = {
+  @description('Name of the gateway.')
+  name: string
+
+  @description('Type of gateway.')
+  gatewayType: ('Vpn' | 'ExpressRoute')
+
+  @description('SKU of the gateway.')
+  sku: ('Basic' | 'VpnGw1AZAZ' | 'VpnGw2AZ' | 'VpnGw3AZ' | 'VpnGw4AZ' | 'VpnGw5AZ' | 'ErGw1AZ' | 'ErGw2AZ' | 'ErGw3AZ' | 'ErGwScale' | 'HighPerformance' | 'Standard' | 'UltraPerformance')
+
+  @description('Type of VPN.')
+  vpnType: string
+
+  @description('Generation of the VPN Gateway.')
+  vpnGatewayGeneration: ('Generation1' | 'Generation2' | 'None' )
+
+  @description('Enable BGP on the gateway.')
+  enableBgp: bool
+
+  @description('Enable Active-Active on the gateway.')
+  activeActive: bool
+
+  @description('Enable BGP Route Translation for NAT on the gateway.')
+  enableBgpRouteTranslationForNat: bool
+
+  @description('Enable DNS Forwarding on the gateway.')
+  enableDnsForwarding: bool
+
+  @description('BGP Peering Address for the gateway.')
+  bgpPeeringAddress: string?
+
+  @description('BGP Settings for the gateway.')
+  bgpSettings: {
+    @minValue(0)
+    @maxValue(4294967295)
+    @description('ASN for the gateway.')
+    asn: int
+
+    @description('BGP Peering Address for the gateway.')
+    bgpPeeringAddress: string?
+
+    @description('Peer Weight for the gateway.')
+    peerWeight: int
+  }
+
+  @description('VPN Client Configuration for the gateway.')
+  vpnClientConfiguration: object?
+
+  @description('Name of the IP Configuration for the gateway.')
+  ipConfigurationName: string
+
+  @description('Name of the Active-Active IP Configuration for the gateway.')
+  ipConfigurationActiveActiveName: string
+}
+
 type lockType = {
   @description('Optional. Specify the name of lock.')
   name: string?
@@ -284,18 +339,18 @@ param parVpnGatewayEnabled bool = true
 
 //ASN must be 65515 if deploying VPN & ER for co-existence to work: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-howto-coexist-resource-manager#limits-and-limitations
 @sys.description('Configuration for VPN virtual network gateway to be deployed.')
-param parVpnGatewayConfig object = {
+param parVpnGatewayConfig virtualNetworkGatewayOptionsType = {
   name: '${parCompanyPrefix}-Vpn-Gateway'
   gatewayType: 'Vpn'
-  sku: 'VpnGw1'
+  sku: 'VpnGw1AZAZ'
   vpnType: 'RouteBased'
-  generation: 'Generation1'
+  vpnGatewayGeneration: 'Generation1'
   enableBgp: false
   activeActive: false
   enableBgpRouteTranslationForNat: false
   enableDnsForwarding: false
   bgpPeeringAddress: ''
-  bgpsettings: {
+  bgpSettings: {
     asn: 65515
     bgpPeeringAddress: ''
     peerWeight: 5
@@ -309,7 +364,7 @@ param parVpnGatewayConfig object = {
 param parExpressRouteGatewayEnabled bool = true
 
 @sys.description('Configuration for ExpressRoute virtual network gateway to be deployed.')
-param parExpressRouteGatewayConfig object = {
+param parExpressRouteGatewayConfig virtualNetworkGatewayOptionsType = {
   name: '${parCompanyPrefix}-ExpressRoute-Gateway'
   gatewayType: 'ExpressRoute'
   sku: 'ErGw1AZ'
@@ -320,10 +375,10 @@ param parExpressRouteGatewayConfig object = {
   enableBgpRouteTranslationForNat: false
   enableDnsForwarding: false
   bgpPeeringAddress: ''
-  bgpsettings: {
-    asn: '65515'
+  bgpSettings: {
+    asn: 65515
     bgpPeeringAddress: ''
-    peerWeight: '5'
+    peerWeight: 5
   }
   ipConfigurationName: 'vnetGatewayConfig'
   ipConfigurationActiveActiveName: 'vnetGatewayConfig2'
@@ -770,7 +825,7 @@ resource resGateway 'Microsoft.Network/virtualNetworkGateways@2024-01-01' = [
       enableDnsForwarding: gateway.enableDnsForwarding
       bgpSettings: (gateway.enableBgp) ? gateway.bgpSettings : null
       gatewayType: gateway.gatewayType
-      vpnGatewayGeneration: (toLower(gateway.gatewayType) == 'vpn') ? gateway.generation : 'None'
+      vpnGatewayGeneration: (toLower(gateway.gatewayType) == 'vpn') ? gateway.vpnGatewayGeneration : 'None'
       vpnType: gateway.vpnType
       sku: {
         name: gateway.sku

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
@@ -26,7 +26,7 @@ type virtualNetworkGatewayOptionsType = {
   gatewayType: ('Vpn' | 'ExpressRoute')
 
   @description('SKU of the gateway.')
-  sku: ('Basic' | 'VpnGw1AZAZ' | 'VpnGw2AZ' | 'VpnGw3AZ' | 'VpnGw4AZ' | 'VpnGw5AZ' | 'ErGw1AZ' | 'ErGw2AZ' | 'ErGw3AZ' | 'ErGwScale' | 'HighPerformance' | 'Standard' | 'UltraPerformance')
+  sku: ('Basic' | 'VpnGw1AZ' | 'VpnGw2AZ' | 'VpnGw3AZ' | 'VpnGw4AZ' | 'VpnGw5AZ' | 'ErGw1AZ' | 'ErGw2AZ' | 'ErGw3AZ' | 'ErGwScale' | 'HighPerformance' | 'Standard' | 'UltraPerformance')
 
   @description('Type of VPN.')
   vpnType: string
@@ -342,7 +342,7 @@ param parVpnGatewayEnabled bool = true
 param parVpnGatewayConfig virtualNetworkGatewayOptionsType = {
   name: '${parCompanyPrefix}-Vpn-Gateway'
   gatewayType: 'Vpn'
-  sku: 'VpnGw1AZAZ'
+  sku: 'VpnGw1AZ'
   vpnType: 'RouteBased'
   vpnGatewayGeneration: 'Generation1'
   enableBgp: false

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.all.json
@@ -124,18 +124,18 @@
       "value": {
         "name": "alz-Vpn-Gateway",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1",
+        "sku": "VpnGw1AZAZ",
         "vpnType": "RouteBased",
-        "generation": "Generation1",
+        "vpnGatewayGeneration": "Generation1",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "vpnClientConfiguration": {},
         "ipConfigurationName": "vnetGatewayConfig",
@@ -151,16 +151,16 @@
         "gatewayType": "ExpressRoute",
         "sku": "Standard",
         "vpnType": "RouteBased",
-        "generation": "None",
+        "vpnGatewayGeneration": "None",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "ipConfigurationName": "vnetGatewayConfig",
         "ipConfigurationActiveActiveName": "vnetGatewayConfig2"

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.all.json
@@ -124,7 +124,7 @@
       "value": {
         "name": "alz-Vpn-Gateway",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1AZAZ",
+        "sku": "VpnGw1AZ",
         "vpnType": "RouteBased",
         "vpnGatewayGeneration": "Generation1",
         "enableBgp": false,

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.az.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.az.all.json
@@ -136,18 +136,18 @@
       "value": {
         "name": "alz-Vpn-Gateway",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1AZ",
+        "sku": "VpnGw1AZAZ",
         "vpnType": "RouteBased",
-        "generation": "Generation1",
+        "vpnGatewayGeneration": "Generation1",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "vpnClientConfiguration": {},
         "ipConfigurationName": "vnetGatewayConfig",
@@ -161,18 +161,18 @@
       "value": {
         "name": "alz-ExpressRoute-Gateway",
         "gatewayType": "ExpressRoute",
-        "sku": "ErGw1Az",
+        "sku": "ErGw1AZ",
         "vpnType": "RouteBased",
-        "generation": "None",
+        "vpnGatewayGeneration": "None",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "ipConfigurationName": "vnetGatewayConfig",
         "ipConfigurationActiveActiveName": "vnetGatewayConfig2"

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.az.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.az.all.json
@@ -136,7 +136,7 @@
       "value": {
         "name": "alz-Vpn-Gateway",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1AZAZ",
+        "sku": "VpnGw1AZ",
         "vpnType": "RouteBased",
         "vpnGatewayGeneration": "Generation1",
         "enableBgp": false,

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.az.multiRegion.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.az.multiRegion.all.json
@@ -251,18 +251,18 @@
       "value": {
         "name": "alz-vpn-gateway",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1AZ",
+        "sku": "VpnGw1AZAZ",
         "vpnType": "RouteBased",
-        "generation": "Generation1",
+        "vpnGatewayGeneration": "vpnGatewayGeneration",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "vpnClientConfiguration": {},
         "ipConfigurationName": "vnetGatewayConfig",
@@ -273,18 +273,18 @@
       "value": {
         "name": "alz-vpn-gateway-secondary",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1AZ",
+        "sku": "VpnGw1AZAZ",
         "vpnType": "RouteBased",
-        "generation": "Generation1",
+        "vpnGatewayGeneration": "vpnGatewayGeneration",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "vpnClientConfiguration": {},
         "ipConfigurationName": "vnetGatewayConfig",
@@ -298,18 +298,18 @@
       "value": {
         "name": "alz-expressroute-gateway",
         "gatewayType": "ExpressRoute",
-        "sku": "ErGw1Az",
+        "sku": "ErGw1AZ",
         "vpnType": "RouteBased",
-        "generation": "None",
+        "vpnGatewayGeneration": "None",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "ipConfigurationName": "vnetGatewayConfig",
         "ipConfigurationActiveActiveName": "vnetGatewayConfig2"
@@ -322,18 +322,18 @@
       "value": {
         "name": "alz-expressroute-gateway-secondary",
         "gatewayType": "ExpressRoute",
-        "sku": "ErGw1Az",
+        "sku": "ErGw1AZ",
         "vpnType": "RouteBased",
-        "generation": "None",
+        "vpnGatewayGeneration": "None",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         }
       }
     },

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.az.multiRegion.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.az.multiRegion.all.json
@@ -251,7 +251,7 @@
       "value": {
         "name": "alz-vpn-gateway",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1AZAZ",
+        "sku": "VpnGw1AZ",
         "vpnType": "RouteBased",
         "vpnGatewayGeneration": "vpnGatewayGeneration",
         "enableBgp": false,
@@ -273,7 +273,7 @@
       "value": {
         "name": "alz-vpn-gateway-secondary",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1AZAZ",
+        "sku": "VpnGw1AZ",
         "vpnType": "RouteBased",
         "vpnGatewayGeneration": "vpnGatewayGeneration",
         "enableBgp": false,

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.min.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/hubNetworking.parameters.min.json
@@ -82,18 +82,18 @@
       "value": {
         "name": "alz-Vpn-Gateway",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1",
+        "sku": "VpnGw1AZ",
         "vpnType": "RouteBased",
-        "generation": "Generation1",
+        "vpnGatewayGeneration": "Generation1",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "ipConfigurationName": "vnetGatewayConfig",
         "ipConfigurationActiveActiveName": "vnetGatewayConfig2"
@@ -108,16 +108,16 @@
         "gatewayType": "ExpressRoute",
         "sku": "Standard",
         "vpnType": "RouteBased",
-        "generation": "None",
+        "vpnGatewayGeneration": "None",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "ipConfigurationName": "vnetGatewayConfig",
         "ipConfigurationActiveActiveName": "vnetGatewayConfig2"

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.all.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.all.json
@@ -157,18 +157,18 @@
       "value": {
         "name": "alz-Vpn-Gateway",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1",
+        "sku": "VpnGw1AZ",
         "vpnType": "RouteBased",
-        "generation": "Generation1",
+        "vpnGatewayGeneration": "Generation1",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "vpnClientConfiguration": {},
         "ipConfigurationName": "vnetGatewayConfig",
@@ -184,16 +184,16 @@
         "gatewayType": "ExpressRoute",
         "sku": "Standard",
         "vpnType": "RouteBased",
-        "generation": "None",
+        "vpnGatewayGeneration": "None",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "ipConfigurationName": "vnetGatewayConfig",
         "ipConfigurationActiveActiveName": "vnetGatewayConfig2"

--- a/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.min.json
+++ b/infra-as-code/bicep/modules/hubNetworking/parameters/mc-hubNetworking.parameters.min.json
@@ -118,18 +118,18 @@
       "value": {
         "name": "alz-Vpn-Gateway",
         "gatewayType": "Vpn",
-        "sku": "VpnGw1",
+        "sku": "VpnGw1AZ",
         "vpnType": "RouteBased",
-        "generation": "Generation1",
+        "vpnGatewayGeneration": "Generation1",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "ipConfigurationName": "vnetGatewayConfig",
         "ipConfigurationActiveActiveName": "vnetGatewayConfig2"
@@ -144,16 +144,16 @@
         "gatewayType": "ExpressRoute",
         "sku": "Standard",
         "vpnType": "RouteBased",
-        "generation": "None",
+        "vpnGatewayGeneration": "None",
         "enableBgp": false,
         "activeActive": false,
         "enableBgpRouteTranslationForNat": false,
         "enableDnsForwarding": false,
         "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
+        "bgpSettings": {
+          "asn": 65515,
           "bgpPeeringAddress": "",
-          "peerWeight": "5"
+          "peerWeight": 5
         },
         "ipConfigurationName": "vnetGatewayConfig",
         "ipConfigurationActiveActiveName": "vnetGatewayConfig2"

--- a/infra-as-code/bicep/modules/hubNetworking/samples/baseline.sample.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/samples/baseline.sample.bicep
@@ -115,7 +115,7 @@ module baseline_hub_network_with_VPN '../hubNetworking.bicep' = {
     parVpnGatewayConfig: {
       name: '${parCompanyPrefix}-Vpn-Gateway'
       gatewayType: 'Vpn'
-      sku: 'VpnGw1AZAZ'
+      sku: 'VpnGw1AZ'
       vpnType: 'RouteBased'
       vpnGatewayGeneration: 'Generation1'
       enableBgp: false

--- a/infra-as-code/bicep/modules/hubNetworking/samples/baseline.sample.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/samples/baseline.sample.bicep
@@ -45,8 +45,6 @@ module baseline_hub_network '../hubNetworking.bicep' = {
       '2'
       '3'
     ]
-    parVpnGatewayConfig: {}
-    parExpressRouteGatewayConfig: {}
   }
 }
 
@@ -71,24 +69,24 @@ module baseline_hub_network_with_ER '../hubNetworking.bicep' = {
       '2'
       '3'
     ]
-    parVpnGatewayConfig: {}
     parExpressRouteGatewayConfig: {
       name: '${parCompanyPrefix}-ExpressRoute-Gateway'
-      gatewaytype: 'ExpressRoute'
+      gatewayType: 'ExpressRoute'
       sku: 'ErGw1AZ'
-      vpntype: 'RouteBased'
+      vpnType: 'RouteBased'
       vpnGatewayGeneration: 'None'
       enableBgp: false
-      activeActive: true
+      activeActive: false
       enableBgpRouteTranslationForNat: false
       enableDnsForwarding: false
-      asn: '65515'
       bgpPeeringAddress: ''
-      bgpsettings: {
-        asn: '65515'
+      bgpSettings: {
+        asn: 65515
         bgpPeeringAddress: ''
-        peerWeight: '5'
+        peerWeight: 5
       }
+      ipConfigurationName: 'vnetGatewayConfig'
+      ipConfigurationActiveActiveName: 'vnetGatewayConfig2'
     }
   }
 }
@@ -116,22 +114,23 @@ module baseline_hub_network_with_VPN '../hubNetworking.bicep' = {
     ]
     parVpnGatewayConfig: {
       name: '${parCompanyPrefix}-Vpn-Gateway'
-      gatewaytype: 'Vpn'
-      sku: 'VpnGw1AZ'
-      vpntype: 'RouteBased'
-      generation: 'Generation1'
+      gatewayType: 'Vpn'
+      sku: 'VpnGw1AZAZ'
+      vpnType: 'RouteBased'
+      vpnGatewayGeneration: 'Generation1'
       enableBgp: false
-      activeActive: true
+      activeActive: false
       enableBgpRouteTranslationForNat: false
       enableDnsForwarding: false
-      asn: 65515
       bgpPeeringAddress: ''
-      bgpsettings: {
+      bgpSettings: {
         asn: 65515
         bgpPeeringAddress: ''
         peerWeight: 5
       }
+      vpnClientConfiguration: {}
+      ipConfigurationName: 'vnetGatewayConfig'
+      ipConfigurationActiveActiveName: 'vnetGatewayConfig2'
     }
-    parExpressRouteGatewayConfig: {}
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Create UDT for virtual network gateway parameters and add allowed values. In particular, with the consolidation and migration of the SKUS to default to availability zones per https://learn.microsoft.com/en-us/azure/vpn-gateway/gateway-sku-consolidation

## Related Issues/Work Items

<!--
- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item (internal Microsoft team member), use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

## This PR fixes/adds/changes/removes

1. Adds UDT with allowed values
2. Fix sample bicep module

### Breaking Changes

### Notice: Breaking Changes in Bicep Module Configuration  

As part of the migration to user-defined types (UDTs) for properties within the `parVpnGatewayConfig` and `parExpressRouteGatewayConfig` parameters, the following breaking changes have been introduced:  

#### 1. Supported SKUs Limited to Availability Zones  
The list of supported SKUs for VPN and ExpressRoute gateways now only includes those with availability zones. This change aligns with the consolidation and migration updates outlined in the official Azure documentation. For more details, refer to the [Gateway SKU Consolidation and Migration Guide](https://learn.microsoft.com/en-us/azure/vpn-gateway/gateway-sku-consolidation).  

#### 2. Property Name Alignment for `parVpnGatewayConfig`  
The `generation` property in `parVpnGatewayConfig` has been renamed to `vpnGatewayGeneration` to align with the schema property name already used for `parExpressRouteGatewayConfig`.  

#### 3. Case Sensitivity of `bgpSettings`  
The `bgpsettings` property is now case-sensitive and must be written as `bgpSettings`.  

##### Subproperty Changes:  
- The `asn` and `peerweight` subproperties within `bgpSettings` now require **integer** values instead of strings, ensuring consistency with the resource schema.  

---

Please update your configurations accordingly to avoid deployment errors.

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
