### PR TITLE
feat: add fallbacktointernet for dns zone

### DIFF
--- a/infra-as-code/bicep/modules/privateDnsZoneLinks/generateddocs/privateDnsZoneLinks.bicep.md
+++ b/infra-as-code/bicep/modules/privateDnsZoneLinks/generateddocs/privateDnsZoneLinks.bicep.md
@@ -6,7 +6,8 @@ Parameter name | Required | Description
 -------------- | -------- | -----------
 parSpokeVirtualNetworkResourceId | No       | The Spoke Virtual Network Resource ID.
 parPrivateDnsZoneResourceId | No       | The Private DNS Zone Resource IDs to associate with the spoke Virtual Network.
-parResourceLockConfig | No       | Resource Lock Configuration for Private DNS Zone Links.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parResolutionPolicy | No       | The resolution policy on the virtual network link. Only applicable for virtual network links to privatelink zones, and for A,AAAA,CNAME queries. When set to 'NxDomainRedirect', Azure DNS resolver falls back to public resolution if private dns query resolution results in non-existent domain response.
+parResourceLockConfig | No       | Resource Lock Configuration for Private DNS Zone Links.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 
 ### parSpokeVirtualNetworkResourceId
 
@@ -19,6 +20,12 @@ The Spoke Virtual Network Resource ID.
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
 
 The Private DNS Zone Resource IDs to associate with the spoke Virtual Network.
+
+### parResolutionPolicy
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+The resolution policy on the virtual network link. Only applicable for virtual network links to privatelink zones, and for A,AAAA,CNAME queries. When set to 'NxDomainRedirect', Azure DNS resolver falls back to public resolution if private dns query resolution results in non-existent domain response.
 
 ### parResourceLockConfig
 
@@ -50,6 +57,9 @@ Resource Lock Configuration for Private DNS Zone Links.
         },
         "parPrivateDnsZoneResourceId": {
             "value": ""
+        },
+        "parResolutionPolicy": {
+            "value": "NxDomainRedirect"
         },
         "parResourceLockConfig": {
             "value": {

--- a/infra-as-code/bicep/modules/privateDnsZoneLinks/generateddocs/privateDnsZoneLinks.bicep.md
+++ b/infra-as-code/bicep/modules/privateDnsZoneLinks/generateddocs/privateDnsZoneLinks.bicep.md
@@ -5,15 +5,25 @@
 Parameter name | Required | Description
 -------------- | -------- | -----------
 parSpokeVirtualNetworkResourceId | No       | The Spoke Virtual Network Resource ID.
+parPrivateDnsZoneLinkResolutionPolicy | No       | Fallback to internet for Azure Private DNS zones.
 parPrivateDnsZoneResourceId | No       | The Private DNS Zone Resource IDs to associate with the spoke Virtual Network.
-parPrivateDnsZoneLinkResolutionPolicy | No       | The resolution policy on the virtual network link. Only applicable for virtual network links to privatelink zones, and for A,AAAA,CNAME queries. When set to 'NxDomainRedirect', Azure DNS resolver falls back to public resolution if private dns query resolution results in non-existent domain response.
-parResourceLockConfig | No       | Resource Lock Configuration for Private DNS Zone Links.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parResourceLockConfig | No       | Resource Lock Configuration for Private DNS Zone Links.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
 
 ### parSpokeVirtualNetworkResourceId
 
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
 
 The Spoke Virtual Network Resource ID.
+
+### parPrivateDnsZoneLinkResolutionPolicy
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Fallback to internet for Azure Private DNS zones.
+
+- Default value: `Default`
+
+- Allowed values: `Default`, `NxDomainRedirect`
 
 ### parPrivateDnsZoneResourceId
 
@@ -49,11 +59,11 @@ Resource Lock Configuration for Private DNS Zone Links.
         "parSpokeVirtualNetworkResourceId": {
             "value": ""
         },
+        "parPrivateDnsZoneLinkResolutionPolicy": {
+            "value": "Default"
+        },
         "parPrivateDnsZoneResourceId": {
             "value": ""
-        },
-        "parPrivateDnsZoneLinkResolutionPolicy": {
-            "value": "NxDomainRedirect"
         },
         "parResourceLockConfig": {
             "value": {

--- a/infra-as-code/bicep/modules/privateDnsZoneLinks/generateddocs/privateDnsZoneLinks.bicep.md
+++ b/infra-as-code/bicep/modules/privateDnsZoneLinks/generateddocs/privateDnsZoneLinks.bicep.md
@@ -6,7 +6,7 @@ Parameter name | Required | Description
 -------------- | -------- | -----------
 parSpokeVirtualNetworkResourceId | No       | The Spoke Virtual Network Resource ID.
 parPrivateDnsZoneResourceId | No       | The Private DNS Zone Resource IDs to associate with the spoke Virtual Network.
-parResolutionPolicy | No       | The resolution policy on the virtual network link. Only applicable for virtual network links to privatelink zones, and for A,AAAA,CNAME queries. When set to 'NxDomainRedirect', Azure DNS resolver falls back to public resolution if private dns query resolution results in non-existent domain response.
+parPrivateDnsZoneLinkResolutionPolicy | No       | The resolution policy on the virtual network link. Only applicable for virtual network links to privatelink zones, and for A,AAAA,CNAME queries. When set to 'NxDomainRedirect', Azure DNS resolver falls back to public resolution if private dns query resolution results in non-existent domain response.
 parResourceLockConfig | No       | Resource Lock Configuration for Private DNS Zone Links.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 
 ### parSpokeVirtualNetworkResourceId
@@ -20,12 +20,6 @@ The Spoke Virtual Network Resource ID.
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
 
 The Private DNS Zone Resource IDs to associate with the spoke Virtual Network.
-
-### parResolutionPolicy
-
-![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
-
-The resolution policy on the virtual network link. Only applicable for virtual network links to privatelink zones, and for A,AAAA,CNAME queries. When set to 'NxDomainRedirect', Azure DNS resolver falls back to public resolution if private dns query resolution results in non-existent domain response.
 
 ### parResourceLockConfig
 
@@ -58,7 +52,7 @@ Resource Lock Configuration for Private DNS Zone Links.
         "parPrivateDnsZoneResourceId": {
             "value": ""
         },
-        "parResolutionPolicy": {
+        "parPrivateDnsZoneLinkResolutionPolicy": {
             "value": "NxDomainRedirect"
         },
         "parResourceLockConfig": {

--- a/infra-as-code/bicep/modules/privateDnsZoneLinks/parameters/privateDnsZoneLinks.parameters.all.json
+++ b/infra-as-code/bicep/modules/privateDnsZoneLinks/parameters/privateDnsZoneLinks.parameters.all.json
@@ -8,7 +8,7 @@
     "parPrivateDnsZoneResourceIds":{
       "value": []
     },
-    "parResolutionPolicy": {
+    "parPrivateDnsZoneLinkResolutionPolicy": {
       "value": "Default"
     }
   }

--- a/infra-as-code/bicep/modules/privateDnsZoneLinks/parameters/privateDnsZoneLinks.parameters.all.json
+++ b/infra-as-code/bicep/modules/privateDnsZoneLinks/parameters/privateDnsZoneLinks.parameters.all.json
@@ -7,6 +7,9 @@
     },
     "parPrivateDnsZoneResourceIds":{
       "value": []
+    },
+    "parResolutionPolicy": {
+      "value": "Default"
     }
   }
 }

--- a/infra-as-code/bicep/modules/privateDnsZoneLinks/privateDnsZoneLinks.bicep
+++ b/infra-as-code/bicep/modules/privateDnsZoneLinks/privateDnsZoneLinks.bicep
@@ -19,7 +19,7 @@ param parSpokeVirtualNetworkResourceId string = ''
   'Default'
   'NxDomainRedirect'
 ])
-param parResolutionPolicy string = 'Default'
+param parPrivateDnsZoneLinkResolutionPolicy string = 'Default'
 
 @sys.description('The Private DNS Zone Resource IDs to associate with the spoke Virtual Network.')
 param parPrivateDnsZoneResourceId string = ''
@@ -42,7 +42,7 @@ resource resPrivateDnsZoneLinkToSpoke 'Microsoft.Network/privateDnsZones/virtual
   name: '${split(parPrivateDnsZoneResourceId, '/')[8]}/dnslink-to-${varSpokeVirtualNetworkName}'
   properties: {
     registrationEnabled: false
-    resolutionPolicy: parResolutionPolicy
+    resolutionPolicy: parPrivateDnsZoneLinkResolutionPolicy
     virtualNetwork: {
       id: parSpokeVirtualNetworkResourceId
     }

--- a/infra-as-code/bicep/modules/privateDnsZoneLinks/privateDnsZoneLinks.bicep
+++ b/infra-as-code/bicep/modules/privateDnsZoneLinks/privateDnsZoneLinks.bicep
@@ -15,7 +15,11 @@ type lockType = {
 param parSpokeVirtualNetworkResourceId string = ''
 
 @sys.description('Fallback to internet for Azure Private DNS zones.')
-param parResolutionPolicy string = 'NxDomainRedirect'
+@allowed([
+  'Default'
+  'NxDomainRedirect'
+])
+param parResolutionPolicy string = 'Default'
 
 @sys.description('The Private DNS Zone Resource IDs to associate with the spoke Virtual Network.')
 param parPrivateDnsZoneResourceId string = ''

--- a/infra-as-code/bicep/modules/privateDnsZoneLinks/privateDnsZoneLinks.bicep
+++ b/infra-as-code/bicep/modules/privateDnsZoneLinks/privateDnsZoneLinks.bicep
@@ -14,6 +14,9 @@ type lockType = {
 @sys.description('The Spoke Virtual Network Resource ID.')
 param parSpokeVirtualNetworkResourceId string = ''
 
+@sys.description('Fallback to internet for Azure Private DNS zones.')
+param parResolutionPolicy string = 'NxDomainRedirect'
+
 @sys.description('The Private DNS Zone Resource IDs to associate with the spoke Virtual Network.')
 param parPrivateDnsZoneResourceId string = ''
 
@@ -35,6 +38,7 @@ resource resPrivateDnsZoneLinkToSpoke 'Microsoft.Network/privateDnsZones/virtual
   name: '${split(parPrivateDnsZoneResourceId, '/')[8]}/dnslink-to-${varSpokeVirtualNetworkName}'
   properties: {
     registrationEnabled: false
+    resolutionPolicy: parResolutionPolicy
     virtualNetwork: {
       id: parSpokeVirtualNetworkResourceId
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Added 
@sys.description('Fallback to internet for Azure Private DNS zones.')
param parResolutionPolicy string = 'NxDomainRedirect' on line 17-18
resolutionPolicy: parResolutionPolicy on line 41

This added the Fallback to internet for Azure Private DNS zones parameter to the Virtual Network Link for the Private DNS


## Related Issues/Work Items

Closes #961

## This PR fixes/adds/changes/removes

Issue is that with Private DNS Zones for PaaS services enabled as of now services that does not have a Private Endpoint does not resolve the Public ### Breaking Changes

<!--
1. *Replace me*
2. *Replace me*
-->

## Testing Evidence

Tested in our environment and it applies the setting

-)
