### PR TITLE
fix: Fix formatting and add logic for null values from custom policies

### DIFF
--- a/.github/scripts/Invoke-PolicyToBicep.ps1
+++ b/.github/scripts/Invoke-PolicyToBicep.ps1
@@ -200,6 +200,11 @@ function New-PolicySetDefinitionsBicepInputTxtFile {
         $groups = $($policySetDefinitionsOutputForBicep[$_][1])
         $definitionVersion = $($policySetDefinitionsOutputForBicep[$_][2])
 
+        # Ensure definitionVersion is always set to ''
+        if ([string]::IsNullOrEmpty($definitionVersion)) {
+          $definitionVersion = "''"
+        }
+
         # If definitionReferenceId or definitionReferenceIdForParameters contains apostrophes, replace that apostrophe with a backslash and an apostrophe for Bicep string escaping
         if ($definitionReferenceId.Contains("'")) {
           $definitionReferenceId = $definitionReferenceId.Replace("'", "\'")
@@ -214,11 +219,10 @@ function New-PolicySetDefinitionsBicepInputTxtFile {
           $definitionReferenceIdForParameters = "['$definitionReferenceIdForParameters']"
 
           # Add nested array of objects to each Policy Set/Initiative Definition in the Bicep variable, without the '.' before the definitionReferenceId to make it an accessor
-          Add-Content -Path "$rootPath/$definitionsSetLongPath/$defintionsSetTxtFileName" -Encoding "utf8" -Value "`t`t`t{`r`n`t`t`t`tdefinitionReferenceId: '$definitionReferenceId'`r`n`t`t`t`tdefinitionId: '$definitionId'`r`n`t`t`t`tdefinitionParameters: $policySetDefParamVarCreation$definitionReferenceIdForParameters.parameters`r`n`t`t`t`tdefinitionGroups: [$groups]`r`n`t`t`t`tdefinitionVersion: $definitionVersion`r`n`t`t`t`t}"
-        }
-        else {
+          Add-Content -Path "$rootPath/$definitionsSetLongPath/$defintionsSetTxtFileName" -Encoding "utf8" -Value "`t`t`t{`r`n`t`t`t`tdefinitionReferenceId: '$definitionReferenceId'`r`n`t`t`t`tdefinitionId: '$definitionId'`r`n`t`t`t`tdefinitionParameters: $policySetDefParamVarCreation$definitionReferenceIdForParameters.parameters`r`n`t`t`t`tdefinitionGroups: [$groups]`r`n`t`t`t`tdefinitionVersion: $definitionVersion`r`n`t`t`t}"
+        } else {
           # Add nested array of objects to each Policy Set/Initiative Definition in the Bicep variable
-          Add-Content -Path "$rootPath/$definitionsSetLongPath/$defintionsSetTxtFileName" -Encoding "utf8" -Value "`t`t`t{`r`n`t`t`t`tdefinitionReferenceId: '$definitionReferenceId'`r`n`t`t`t`tdefinitionId: '$definitionId'`r`n`t`t`t`tdefinitionParameters: $policySetDefParamVarCreation.$definitionReferenceIdForParameters.parameters`r`n`t`t`t`tdefinitionGroups: [$groups]`r`n`t`t`t`tdefinitionVersion: '$definitionVersion'`r`n`t`t`t`t}"
+          Add-Content -Path "$rootPath/$definitionsSetLongPath/$defintionsSetTxtFileName" -Encoding "utf8" -Value "`t`t`t{`r`n`t`t`t`tdefinitionReferenceId: '$definitionReferenceId'`r`n`t`t`t`tdefinitionId: '$definitionId'`r`n`t`t`t`tdefinitionParameters: $policySetDefParamVarCreation.$definitionReferenceIdForParameters.parameters`r`n`t`t`t`tdefinitionGroups: [$groups]`r`n`t`t`t`tdefinitionVersion: $definitionVersion`r`n`t`t`t}"
         }
       }
     }


### PR DESCRIPTION
This pull request includes changes to the `New-PolicySetDefinitionsBicepInputTxtFile` function in the `.github/scripts/Invoke-PolicyToBicep.ps1` file. The updates are primarily focused on ensuring the `definitionVersion` is always set and improving the handling of `Add-Content` commands.

![image](https://github.com/user-attachments/assets/304689b2-78cd-434e-8872-af79a83d9626)

Key changes:

* Ensured `definitionVersion` is always set to an empty string if it is null or empty.
* Simplified the `Add-Content` command by removing redundant else block and ensuring consistent formatting.