### PR TITLE
refactor: Remove redundant ternary

### DIFF
--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep
@@ -671,7 +671,7 @@ var varCuaid = '2686e846-5fdc-4d4f-b533-16dcb09d6e6c'
 
 // ZTN Telemetry
 var varZtnP1CuaId = '3ab23b1e-c5c5-42d4-b163-1402384ba2db'
-var varZtnP1Trigger = (parDdosEnabled && parAzFirewallEnabled && (parAzFirewallTier == 'Premium')) ? true : false
+var varZtnP1Trigger = (parDdosEnabled && parAzFirewallEnabled && (parAzFirewallTier == 'Premium'))
 
 var varZtnP1TriggerSecondaryLocation = (parDdosEnabledSecondaryLocation && parAzFirewallEnabledSecondaryLocation && (parAzFirewallTierSecondaryLocation == 'Premium'))
   ? true

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep
@@ -411,7 +411,7 @@ var varCuaid = '2686e846-5fdc-4d4f-b533-16dcb09d6e6c'
 
 // ZTN Telemetry
 var varZtnP1CuaId = '3ab23b1e-c5c5-42d4-b163-1402384ba2db'
-var varZtnP1Trigger = (parDdosEnabled && parAzFirewallEnabled && (parAzFirewallTier == 'Premium')) ? true : false
+var varZtnP1Trigger = (parDdosEnabled && parAzFirewallEnabled && (parAzFirewallTier == 'Premium'))
 
 var varAzFirewallUseCustomPublicIps = length(parAzFirewallCustomPublicIps) > 0
 

--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
@@ -92,7 +92,7 @@ var varCuaid = '98cef979-5a6b-403b-83c7-10c8f04ac9a2'
 
 // ZTN Telemetry
 var varZtnP1CuaId = '4eaba1fc-d30a-4e63-a57f-9e6c3d86a318'
-var varZtnP1Trigger = ((!contains(parExcludedPolicyAssignments, varPolicyAssignmentDenySubnetWithoutNsg.libDefinition.name)) && (!contains(parExcludedPolicyAssignments, varPolicyAssignmentDenyStoragehttp.libDefinition.name))) ? true : false
+var varZtnP1Trigger = ((!contains(parExcludedPolicyAssignments, varPolicyAssignmentDenySubnetWithoutNsg.libDefinition.name)) && (!contains(parExcludedPolicyAssignments, varPolicyAssignmentDenyStoragehttp.libDefinition.name)))
 
 // **Variables**
 // Orchestration Module Variables

--- a/infra-as-code/bicep/modules/spokeNetworking/spokeNetworking.bicep
+++ b/infra-as-code/bicep/modules/spokeNetworking/spokeNetworking.bicep
@@ -90,11 +90,11 @@ resource resSpokeVirtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' =
         parSpokeNetworkAddressPrefix
       ]
     }
-    enableDdosProtection: (!empty(parDdosProtectionPlanId) ? true : false)
-    ddosProtectionPlan: (!empty(parDdosProtectionPlanId) ? true : false) ? {
+    enableDdosProtection: !empty(parDdosProtectionPlanId)
+    ddosProtectionPlan: !empty(parDdosProtectionPlanId) ? {
       id: parDdosProtectionPlanId
     } : null
-    dhcpOptions: (!empty(parDnsServerIps) ? true : false) ? {
+    dhcpOptions: !empty(parDnsServerIps) ? {
       dnsServers: parDnsServerIps
     } : null
   }

--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -276,12 +276,7 @@ var varCuaid = '7f94f23b-7a59-4a5c-9a8d-2a253a566f61'
 
 // ZTN Telemetry
 var varZtnP1CuaId = '3ab23b1e-c5c5-42d4-b163-1402384ba2db'
-var varZtnP1Trigger = (parDdosEnabled && !(contains(map(parVirtualWanHubs, hub => hub.parAzFirewallEnabled), false)) && (contains(
-    map(parVirtualWanHubs, hub => hub.parAzFirewallTier),
-    'Premium'
-  )))
-  ? true
-  : false
+var varZtnP1Trigger = (parDdosEnabled && !(contains(map(parVirtualWanHubs, hub => hub.parAzFirewallEnabled), false)) && (contains(map(parVirtualWanHubs, hub => hub.?parAzFirewallTier), 'Premium')))
 
 // Azure Firewalls in Hubs
 var varAzureFirewallInHubs = filter(parVirtualWanHubs, hub => hub.parAzFirewallEnabled == true)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary


This pull request includes several changes to the Bicep files in the `infra-as-code` directory, focusing on simplifying conditional expressions and improving readability. The most important changes include the removal of unnecessary ternary operators and the simplification of conditions.

Simplification of conditional expressions:

* [`infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep`](diffhunk://#diff-0cf6e0bf8bdcc2cf1baa69e9d2bbe0c1f9896eb1079522008bb669f8b6c352a7L674-R674): Simplified the `varZtnP1Trigger` variable by removing the unnecessary ternary operator.
* [`infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep`](diffhunk://#diff-6f15d7e8d605ac4753479b21282427b592dfde471ef345500fc2dbd050c2f422L414-R414): Simplified the `varZtnP1Trigger` variable by removing the unnecessary ternary operator.
* [`infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep`](diffhunk://#diff-90b5177f0a982776fb0b5ac49607081d27a7285e686a0308d588520f1b89c0aeL95-R95): Simplified the `varZtnP1Trigger` variable by removing the unnecessary ternary operator.
* [`infra-as-code/bicep/modules/spokeNetworking/spokeNetworking.bicep`](diffhunk://#diff-ae71979662b7673c94b99a1bd5e14af4559beb98c89a5c20624a44d0624e0349L93-R97): Simplified the `enableDdosProtection`, `ddosProtectionPlan`, and `dhcpOptions` properties by removing unnecessary ternary operators.

## Related Issues/Work Items

<!--
- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item (internal Microsoft team member), use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

## This PR fixes/adds/changes/removes

<!--
1. *Replace me*
2. *Replace me*
3. *Replace me*
-->

### Breaking Changes

None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
