### PR TITLE
Sidecar network

### DIFF
--- a/accelerator/.config/ALZ-Powershell-Auto.config.json
+++ b/accelerator/.config/ALZ-Powershell-Auto.config.json
@@ -322,6 +322,10 @@
               "Destination": "Parameters"
             },
             {
+              "Name": "parSidecarVirtualNetwork.value.location",
+              "Destination": "Parameters"
+            },
+            {
               "Name": "parPrivateDnsZonesLocation.value",
               "Destination": "Parameters"
             },

--- a/infra-as-code/bicep/modules/vwanConnectivity/README.md
+++ b/infra-as-code/bicep/modules/vwanConnectivity/README.md
@@ -18,6 +18,7 @@ Module deploys the following resources which can be configured by parameters:
 - [Parameters for Azure Commercial Cloud](generateddocs/vwanConnectivity.bicep.md)
 
 > **NOTE:**
+>
 > - Within the `parVirtualWanHubs` parameter, the following keys (parVpnGatewayCustomName, parExpressRouteGatewayCustomName, parAzFirewallCustomName, and parVirtualWanHubCustomName) can be added to create custom names for the associated resources.
 >
 > - Although there are generated parameter markdowns for Azure Commercial Cloud, this same module can still be used in Azure China. Example parameter are in the [parameters](./parameters/) folder.
@@ -64,6 +65,7 @@ In this example, the resources required for Virtual WAN connectivity will be dep
 > For the examples below we assume you have downloaded or cloned the Git repo as-is and are in the root of the repository as your selected directory in your terminal of choice.
 
 ### Azure CLI
+
 ```bash
 # For Azure global regions
 # Set Platform connectivity subscription ID as the the current subscription
@@ -86,7 +88,9 @@ az group create \
 
 az deployment group create --name ${NAME:0:63} --resource-group $GROUP --template-file $TEMPLATEFILE --parameters $PARAMETERS
 ```
+
 OR
+
 ```bash
 # For Azure China regions
 # Set Platform connectivity subscription ID as the the current subscription
@@ -137,7 +141,9 @@ New-AzResourceGroup `
 
 New-AzResourceGroupDeployment @inputObject
 ```
+
 OR
+
 ```powershell
 # For Azure China regions
 # Set Platform connectivity subscription ID as the the current subscription
@@ -162,6 +168,7 @@ New-AzResourceGroup `
 
 New-AzResourceGroupDeployment @inputObject
   ```
+
 ## Example Output in Azure global regions
 
 ![Example Deployment Output](media/exampleDeploymentOutputConnectivity.png "Example Deployment Output in Azure global regions")
@@ -169,6 +176,7 @@ New-AzResourceGroupDeployment @inputObject
 ![Example Virtual WAN Deployment Output](media/exampleDeploymentOutput.png "Example Virtual WAN Deployment Output in Azure global regions")
 
 ## Example Output in Azure China regions
+
 ![Example Deployment Output](media/mc-exampleDeploymentOutputConnectivity.png "Example Deployment Output in Azure China")
 
 ![Example Virtual WAN Deployment Output](media/mc-exampleDeploymentOutput.png "Example Virtual WAN Deployment Output in Azure China")

--- a/infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md
+++ b/infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md
@@ -8,17 +8,18 @@ Parameter name | Required | Description
 -------------- | -------- | -----------
 parLocation    | No       | Region in which the resource group was created.
 parCompanyPrefix | No       | Prefix value which will be prepended to all resource names.
-parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parGlobalResourceLock | No       | Global Resource Lock Configuration used for all resources deployed in this module.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parVirtualHubEnabled | No       | Switch to enable/disable Virtual Hub deployment.
 parVirtualWanName | No       | Prefix Used for Virtual WAN.
 parVirtualWanType | No       | The type of Virtual WAN to create.
-parVirtualWanLock | No       | Resource Lock Configuration for Virtual WAN.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parVirtualWanLock | No       | Resource Lock Configuration for Virtual WAN.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parVirtualWanHubName | No       | Prefix Used for Virtual WAN Hub.
 parVirtualWanHubDefaultRouteName | No       | The name of the route table that manages routing between the Virtual WAN Hub and the Azure Firewall.
-parVirtualWanHubs | No       | Array Used for multiple Virtual WAN Hubs deployment. Each object in the array represents an individual Virtual WAN Hub configuration. Add/remove additional objects in the array to meet the number of Virtual WAN Hubs required.  - `parVpnGatewayEnabled` - Switch to enable/disable VPN Gateway deployment on the respective Virtual WAN Hub. - `parExpressRouteGatewayEnabled` - Switch to enable/disable ExpressRoute Gateway deployment on the respective Virtual WAN Hub. - `parAzFirewallEnabled` - Switch to enable/disable Azure Firewall deployment on the respective Virtual WAN Hub. - `parVirtualHubAddressPrefix` - The IP address range in CIDR notation for the vWAN virtual Hub to use. - `parHubLocation` - The Virtual WAN Hub location. - `parHubRoutingPreference` - The Virtual WAN Hub routing preference. The allowed values are `ASPath`, `VpnGateway`, `ExpressRoute`. - `parVirtualRouterAutoScaleConfiguration` - The Virtual WAN Hub capacity. The value should be between 2 to 50. - `parVirtualHubRoutingIntentDestinations` - The Virtual WAN Hub routing intent destinations, leave empty if not wanting to enable routing intent. The allowed values are `Internet`, `PrivateTraffic`.  
-parVpnGatewayLock | No       | Resource Lock Configuration for Virtual WAN Hub VPN Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
-parExpressRouteGatewayLock | No       | Resource Lock Configuration for Virtual WAN Hub ExpressRoute Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
-parVirtualWanHubsLock | No       | Resource Lock Configuration for Virtual WAN Hub.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parVirtualWanHubs | No       | Array Used for multiple Virtual WAN Hubs deployment. Each object in the array represents an individual Virtual WAN Hub configuration. Add/remove additional objects in the array to meet the number of Virtual WAN Hubs required.  - `parVpnGatewayEnabled` - Switch to enable/disable VPN Gateway deployment on the respective Virtual WAN Hub. - `parExpressRouteGatewayEnabled` - Switch to enable/disable ExpressRoute Gateway deployment on the respective Virtual WAN Hub. - `parAzFirewallEnabled` - Switch to enable/disable Azure Firewall deployment on the respective Virtual WAN Hub. - `parVirtualHubAddressPrefix` - The IP address range in CIDR notation for the vWAN virtual Hub to use. - `parHubLocation` - The Virtual WAN Hub location. - `parHubRoutingPreference` - The Virtual WAN Hub routing preference. The allowed values are `ASPath`, `VpnGateway`, `ExpressRoute`. - `parVirtualRouterAutoScaleConfiguration` - The Virtual WAN Hub capacity. The value should be between 2 to 50. - `parVirtualHubRoutingIntentDestinations` - The Virtual WAN Hub routing intent destinations, leave empty if not wanting to enable routing intent. The allowed values are `Internet`, `PrivateTraffic`.
+parSidecarVirtualNetwork | No       | Sidecar Virtual Network configuration object. Used to optionally deploy a sidecar VNet alongside the vWAN Hub. The object supports the following properties:  - `name` (string): The name of the sidecar virtual network.  - `sidecarVirtualNetworkEnabled` (bool): Switch to enable/disable the sidecar virtual network.  - `addressPrefixes` (array of string): The address space of the sidecar virtual network.  - `location` (string): The location of the sidecar virtual network.  - `virtualHubIdOverride` (string, optional): Resource ID of the virtual hub to associate with the sidecar VNet.  - `flowTimeoutInMinutes` (int): Flow timeout in minutes for the virtual network.  - `ipamPoolNumberOfIpAddresses` (string, optional): Number of IP addresses allocated from the pool (used with IPAM pool resource ID).  - `lock` (object, optional): Resource lock configuration for the virtual network.  - `vnetPeerings` (array, optional): Additional virtual network peerings.  - `subnets` (array, optional): Subnets for the virtual network.  - `vnetEncryption` (bool): Switch to enable/disable VNet encryption.  - `vnetEncryptionEnforcement` (string, optional): If the encrypted VNet allows VMs that do not support encryption. Allowed values: `AllowUnencrypted`, `DropUnencrypted`.  - `roleAssignments` (array, optional): Role assignments for the virtual network.  - `virtualNetworkBgpCommunity` (string, optional): BGP community for the virtual network.  - `diagnosticSettings` (array, optional): Diagnostic settings for the virtual network.  - `dnsServers` (array, optional): DNS servers for the virtual network.  - `enableVmProtection` (bool, optional): Switch to enable/disable VM protection for the virtual network.  - `ddosProtectionPlanResourceIdOverride` (string, optional): DDoS protection plan resource ID.
+parVpnGatewayLock | No       | Resource Lock Configuration for Virtual WAN Hub VPN Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parExpressRouteGatewayLock | No       | Resource Lock Configuration for Virtual WAN Hub ExpressRoute Gateway.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
+parVirtualWanHubsLock | No       | Resource Lock Configuration for Virtual WAN Hub.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parVpnGatewayName | No       | VPN Gateway Name.
 parExpressRouteGatewayName | No       | ExpressRoute Gateway Name.
 parAzFirewallName | No       | Azure Firewall Name.
@@ -26,17 +27,17 @@ parAzFirewallPolicyDeploymentStyle | No       | The deployment style of the Azur
 parAzFirewallPoliciesName | No       | Azure Firewall Policies Name. This is used to automatically generate a name for the Azure Firewall Policy following concat of the pattern `parAzFirewallPoliciesName-hub.parHubLocation` if you want to provide a true custom name then specify a value in each object in the array of `parVirtualWanHubs.parAzFirewallPolicyCustomName`.
 parAzFirewallPoliciesAutoLearn | No       | The operation mode for automatically learning private ranges to not be SNAT.
 parAzFirewallPoliciesPrivateRanges | No       | Private IP addresses/IP ranges to which traffic will not be SNAT.
-parAzureFirewallLock | No       | Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parAzureFirewallLock | No       | Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parVpnGatewayScaleUnit | No       | The scale unit for this VPN Gateway.
 parExpressRouteGatewayScaleUnit | No       | The scale unit for this ExpressRoute Gateway.
 parDdosEnabled | No       | Switch to enable/disable DDoS Network Protection deployment.
 parDdosPlanName | No       | DDoS Plan Name.
-parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parDdosLock    | No       | Resource Lock Configuration for DDoS Plan.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parPrivateDnsZonesEnabled | No       | Switch to enable/disable Private DNS Zones deployment.
 parPrivateDnsZonesResourceGroup | No       | Resource Group Name for Private DNS Zones.
 parPrivateDnsZones | No       | Array of DNS Zones to provision in Hub Virtual Network. Default: All known Azure Private DNS Zones, baked into underlying AVM module see: https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones#parameter-privatelinkprivatednszones
 parVirtualNetworkResourceIdsToLinkTo | No       | Array of Resource IDs of VNets to link to Private DNS Zones.
-parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
+parPrivateDNSZonesLock | No       | Resource Lock Configuration for Private DNS Zone(s).  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.
 parTags        | No       | Tags you would like to be applied to all resources in this module.
 parTelemetryOptOut | No       | Set Parameter to true to Opt-out of deployment telemetry
 
@@ -138,6 +139,12 @@ Array Used for multiple Virtual WAN Hubs deployment. Each object in the array re
 - `parVirtualHubRoutingIntentDestinations` - The Virtual WAN Hub routing intent destinations, leave empty if not wanting to enable routing intent. The allowed values are `Internet`, `PrivateTraffic`.
 
 
+
+### parSidecarVirtualNetwork
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Sidecar Virtual Network configuration object. Used to optionally deploy a sidecar VNet alongside the vWAN Hub. The object supports the following properties:  - `name` (string): The name of the sidecar virtual network.  - `sidecarVirtualNetworkEnabled` (bool): Switch to enable/disable the sidecar virtual network.  - `addressPrefixes` (array of string): The address space of the sidecar virtual network.  - `location` (string): The location of the sidecar virtual network.  - `virtualHubIdOverride` (string, optional): Resource ID of the virtual hub to associate with the sidecar VNet.  - `flowTimeoutInMinutes` (int): Flow timeout in minutes for the virtual network.  - `ipamPoolNumberOfIpAddresses` (string, optional): Number of IP addresses allocated from the pool (used with IPAM pool resource ID).  - `lock` (object, optional): Resource lock configuration for the virtual network.  - `vnetPeerings` (array, optional): Additional virtual network peerings.  - `subnets` (array, optional): Subnets for the virtual network.  - `vnetEncryption` (bool): Switch to enable/disable VNet encryption.  - `vnetEncryptionEnforcement` (string, optional): If the encrypted VNet allows VMs that do not support encryption. Allowed values: `AllowUnencrypted`, `DropUnencrypted`.  - `roleAssignments` (array, optional): Role assignments for the virtual network.  - `virtualNetworkBgpCommunity` (string, optional): BGP community for the virtual network.  - `diagnosticSettings` (array, optional): Diagnostic settings for the virtual network.  - `dnsServers` (array, optional): DNS servers for the virtual network.  - `enableVmProtection` (bool, optional): Switch to enable/disable VM protection for the virtual network.  - `ddosProtectionPlanResourceIdOverride` (string, optional): DDoS protection plan resource ID.
 
 ### parVpnGatewayLock
 
@@ -423,6 +430,33 @@ outAzFwPrivateIps | array |
                     "parAzFirewallAvailabilityZones": []
                 }
             ]
+        },
+        "parSidecarVirtualNetwork": {
+            "value": {
+                "name": "mySidecarVnet",
+                "sidecarVirtualNetworkEnabled": true,
+                "addressPrefixes": [
+                    "10.101.0.0/23"
+                ],
+                "location": "[parameters('parLocation')]",
+                "virtualHubIdOverride": "[resourceId('Microsoft.Network/virtualHubs', parameters('parVirtualWanHubName'))]",
+                "flowTimeoutInMinutes": 10,
+                "ipamPoolNumberOfIpAddresses": "5",
+                "lock": {
+                    "kind": "None",
+                    "notes": "This lock was created by the ALZ Bicep vWAN Connectivity Module."
+                },
+                "vnetPeerings": [],
+                "subnets": [],
+                "vnetEncryption": true,
+                "vnetEncryptionEnforcement": "AllowUnencrypted",
+                "roleAssignments": [],
+                "virtualNetworkBgpCommunity": "65000:100",
+                "diagnosticSettings": [],
+                "dnsServers": [],
+                "enableVmProtection": true,
+                "ddosProtectionPlanResourceIdOverride": "[resourceId('Microsoft.Network/ddosProtectionPlans', parameters('parDdosPlanName'))]"
+            }
         },
         "parVpnGatewayLock": {
             "value": {

--- a/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.all.json
+++ b/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.all.json
@@ -57,6 +57,33 @@
         }
       ]
     },
+    "parSidecarVirtualNetwork": {
+      "value": {
+        "name": "alz-vnet-sidecar-eastus",
+        "sidecarVirtualNetworkEnabled": false,
+        "addressPrefixes": [
+          "10.101.0.0/24"
+        ],
+        "location": "eastus",
+        "virtualHubIdOverride": null,
+        "flowTimeoutInMinutes": 0,
+        "ipamPoolNumberOfIpAddresses": null,
+        "lock": {
+          "name": "alz-vnet-sidecar-lock",
+          "kind": "None"
+        },
+        "vnetPeerings": [],
+        "subnets": [],
+        "vnetEncryption": false,
+        "vnetEncryptionEnforcement": null,
+        "roleAssignments": [],
+        "virtualNetworkBgpCommunity": null,
+        "diagnosticSettings": [],
+        "dnsServers": [],
+        "enableVmProtection": false,
+        "ddosProtectionPlanResourceIdOverride": null
+      }
+    },
     "parVpnGatewayScaleUnit": {
       "value": 1
     },

--- a/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.all.json
+++ b/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.all.json
@@ -54,6 +54,33 @@
         }
       ]
     },
+    "parSidecarVirtualNetwork": {
+      "value": {
+        "name": "alz-vnet-sidecar-eastus",
+        "sidecarVirtualNetworkEnabled": false,
+        "addressPrefixes": [
+          "10.101.0.0/24"
+        ],
+        "location": "eastus",
+        "virtualHubIdOverride": null,
+        "flowTimeoutInMinutes": 0,
+        "ipamPoolNumberOfIpAddresses": null,
+        "lock": {
+          "name": "alz-vnet-sidecar-lock",
+          "kind": "None"
+        },
+        "vnetPeerings": [],
+        "subnets": [],
+        "vnetEncryption": false,
+        "vnetEncryptionEnforcement": null,
+        "roleAssignments": [],
+        "virtualNetworkBgpCommunity": null,
+        "diagnosticSettings": [],
+        "dnsServers": [],
+        "enableVmProtection": false,
+        "ddosProtectionPlanResourceIdOverride": null
+      }
+    },
     "parVpnGatewayScaleUnit": {
       "value": 1
     },

--- a/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.multiRegion.all.json
+++ b/infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.multiRegion.all.json
@@ -80,6 +80,33 @@
         }
       ]
     },
+    "parSidecarVirtualNetwork": {
+      "value": {
+        "name": "alz-vnet-sidecar-eastus",
+        "sidecarVirtualNetworkEnabled": false,
+        "addressPrefixes": [
+          "10.101.0.0/24"
+        ],
+        "location": "eastus",
+        "virtualHubIdOverride": null,
+        "flowTimeoutInMinutes": 0,
+        "ipamPoolNumberOfIpAddresses": null,
+        "lock": {
+          "name": "alz-vnet-sidecar-lock",
+          "kind": "None"
+        },
+        "vnetPeerings": [],
+        "subnets": [],
+        "vnetEncryption": false,
+        "vnetEncryptionEnforcement": null,
+        "roleAssignments": [],
+        "virtualNetworkBgpCommunity": null,
+        "diagnosticSettings": [],
+        "dnsServers": [],
+        "enableVmProtection": false,
+        "ddosProtectionPlanResourceIdOverride": null
+      }
+    },
     "parVpnGatewayScaleUnit": {
       "value": 1
     },

--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -67,6 +67,22 @@ type virtualWanOptionsType = ({
   parAzFirewallAvailabilityZones: azFirewallAvailabilityZones?
 })[]
 
+type sideCarVirtualNetworkType = {
+  @description('The name of the sidecar virtual network.')
+  name: string
+
+  @description('The address space of the sidecar virtual network.')
+  addressPrefixes: string[]
+
+  @description('The location of the sidecar virtual network.')
+  location: string
+
+  @description()
+
+  @description('The resource ID of the virtual hub to associate with the sidecar virtual network.')
+  virtualHubId: string
+}
+
 type lockType = {
   @description('Optional. Specify the name of lock.')
   name: string?
@@ -150,6 +166,14 @@ param parVirtualWanHubs virtualWanOptionsType = [
     parAzFirewallAvailabilityZones: []
   }
 ]
+
+param parSidecarVirtualNetwork sideCarVirtualNetworkType = {
+  name: 'vnet-sidecar-${parLocation}'
+  addressPrefixes: [
+    '10.101.0.0/24'
+  ]
+  location: parLocation
+}
 
 @sys.description('''Resource Lock Configuration for Virtual WAN Hub VPN Gateway.
 
@@ -384,6 +408,33 @@ resource resVhubRoutingIntent 'Microsoft.Network/virtualHubs/routingIntent@2024-
     }
   }
 ]
+
+module modSidecarVirtualNetwork 'br/public:avm/res/network/virtual-network:0.7.0' = {
+  params: {
+    name: parSidecarVirtualNetwork.name
+    addressPrefixes: parSidecarVirtualNetwork.addressPrefixes
+    location: parLocation
+    flowTimeoutInMinutes:
+    ipamPoolNumberOfIpAddresses:
+    lock:
+    peerings:
+    subnets:[
+      {
+        name:
+      }
+    ]
+    vnetEncryption:
+    vnetEncryptionEnforcement:
+    roleAssignments:
+    virtualNetworkBgpCommunity:
+    tags: parTags
+    diagnosticSettings: []
+    dnsServers: []
+    enableVmProtection:
+    ddosProtectionPlanResourceId: parDdosEnabled ? resDdosProtectionPlan.id : null
+    enableTelemetry: parTelemetryOptOut ? false : true
+  }
+}
 
 resource resVpnGateway 'Microsoft.Network/vpnGateways@2024-05-01' = [
   for (hub, i) in parVirtualWanHubs: if ((parVirtualHubEnabled) && (hub.parVpnGatewayEnabled)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This pull request introduces significant enhancements to the Virtual WAN (vWAN) Connectivity module, primarily focusing on the addition of a configurable sidecar Virtual Network (VNet) feature. It also includes updates to improve parameter flexibility and documentation. Below are the most important changes grouped by theme:

### New Feature: Sidecar Virtual Network (VNet)
* Added a new `parSidecarVirtualNetwork` parameter to support the optional deployment of a sidecar VNet alongside the vWAN Hub. This includes detailed configuration options such as `name`, `addressPrefixes`, `location`, `vnetEncryption`, and more (`infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep`, `infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md`, `infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.all.json`, `infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.all.json`, `infra-as-code/bicep/modules/vwanConnectivity/parameters/vwanConnectivity.parameters.az.multiRegion.all.json`, [[1]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdR210-R234) [[2]](diffhunk://#diff-42fb4e22170e32926719c18e2bee1f1fc1d5b0a49106572e59d4858f59d22f83R19) [[3]](diffhunk://#diff-42fb4e22170e32926719c18e2bee1f1fc1d5b0a49106572e59d4858f59d22f83R434-R460) [[4]](diffhunk://#diff-738d81e8ca299919f381069a16b389e5db8e96d4bedf70463ee3c2bf37ea841dR60-R86) [[5]](diffhunk://#diff-de8298b37ab7ea7cd897f602a6247f1dad04e00809ac756fac5c262ea09327e3R57-R83) [[6]](diffhunk://#diff-70de4741bd3e8a057e1b3559a955eae93d5fcfd4f0d65226f7e90c8ebbb79b11R83-R109).

* Integrated a new Bicep module (`modSidecarVirtualNetwork`) to deploy the sidecar VNet and its associated configurations, including peerings with the vWAN Hub (`infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep`, [infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicepR469-R499](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdR469-R499)).

### Parameter and Resource Enhancements
* Introduced a new type definition `sideCarVirtualNetworkType` to encapsulate all properties for the sidecar VNet, improving modularity and clarity in parameter handling (`infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep`, [infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicepR70-R125](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdR70-R125)).

* Updated the vWAN Hub and associated resources to use optional chaining (`?`) for improved flexibility and to handle cases where certain parameters may not be defined (`infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep`, [[1]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL372-R453) [[2]](diffhunk://#diff-c1737d2a8574c4739b210742ea77b76d090d911db834a45abe5e6b6ad67776fdL457-R572).

### Documentation Updates
* Expanded the generated documentation to include details about the new `parSidecarVirtualNetwork` parameter, its properties, and usage examples (`infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md`, [infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.mdR143-R148](diffhunk://#diff-42fb4e22170e32926719c18e2bee1f1fc1d5b0a49106572e59d4858f59d22f83R143-R148)).

* Improved the `README.md` file to clarify usage scenarios, including Azure China regions, and added formatting fixes (`infra-as-code/bicep/modules/vwanConnectivity/README.md`, [[1]](diffhunk://#diff-6cec91904fa66802320991e7ad70fe58f73337be2cf83fe1e7330f15f2faadf1R21) [[2]](diffhunk://#diff-6cec91904fa66802320991e7ad70fe58f73337be2cf83fe1e7330f15f2faadf1R68) [[3]](diffhunk://#diff-6cec91904fa66802320991e7ad70fe58f73337be2cf83fe1e7330f15f2faadf1R91-R93) [[4]](diffhunk://#diff-6cec91904fa66802320991e7ad70fe58f73337be2cf83fe1e7330f15f2faadf1R144-R146) [[5]](diffhunk://#diff-6cec91904fa66802320991e7ad70fe58f73337be2cf83fe1e7330f15f2faadf1R171-R179).

### Configuration File Updates
* Updated the `.config` file to include the new sidecar VNet parameter mapping (`accelerator/.config/ALZ-Powershell-Auto.config.json`, [accelerator/.config/ALZ-Powershell-Auto.config.jsonR324-R327](diffhunk://#diff-a5de3e24ccb80825a0d7b8004ca118e9856a96eecc107710e832a04f95b67880R324-R327)). 

These changes collectively enhance the flexibility, usability, and documentation of the vWAN Connectivity module, making it easier to deploy and manage complex network configurations.
## Related Issues/Work Items

Fixes AB#39034

## This PR fixes/adds/changes/removes

### Breaking Changes

1. None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
