### PR TITLE
fix: deploy-vnet-peering-vwan-name-lenght-fix

### DIFF
--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -484,7 +484,7 @@ module modSidecarVirtualNetwork 'br/public:avm/res/network/virtual-network:0.7.0
 
 module modVnetPeeringVwan '../vnetPeeringVwan/vnetPeeringVwan.bicep' = [
   for (hub, i) in parVirtualWanHubs: if (hub.parSidecarVirtualNetwork.sidecarVirtualNetworkEnabled) {
-    name: 'deploy-vnet-peering-vwan-${hub.parSidecarVirtualNetwork.?name}-${hub.parHubLocation}'
+    name: take('deploy-vnet-peering-vwan-${hub.parSidecarVirtualNetwork.?name}-${hub.parHubLocation}', 64)
     scope: subscription()
     params: {
       parRemoteVirtualNetworkResourceId: modSidecarVirtualNetwork[i].outputs.resourceId


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixes sidecar network for VWAN peering deployment name not limited to 64 maximum length

## Related Issues/Work Items

Fixes: #1041

## This PR fixes/adds/changes/removes

Uses 'take' to support long sidecar VNET names in deployment name.

### Breaking Changes

None

## Testing Evidence

Not tested only syntax updates

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
