### PR TITLE
fix: add fix for MDFC discovery tier - destroy script

### DIFF
--- a/accelerator/scripts/destroy-landing-zone.ps1
+++ b/accelerator/scripts/destroy-landing-zone.ps1
@@ -131,9 +131,15 @@ ForEach ($subscription in $subscriptionsToClean) {
         $currentMdfcForSub = $currentMdfcForSubUnfiltered | Where-Object { $_.PricingTier -ne "Free" }
 
         ForEach ($mdfcPricingTier in $currentMdfcForSub) {
-            Write-Output "Resetting $($mdfcPricingTier.Name) to Free MDFC Pricing Tier for Subscription: $($subscription.name)"
+            if ("Discovery" -eq $mdfcPricingTier.Name) {
+                Write-Output "Resetting $($mdfcPricingTier.Name) to Standard MDFC Pricing Tier, as only tier available, for Subscription: $($subscription.name)"
 
-            Set-AzSecurityPricing -Name $mdfcPricingTier.Name -PricingTier 'Free' | Out-Null
+                Set-AzSecurityPricing -Name $mdfcPricingTier.Name -PricingTier 'Standard' | Out-Null
+            } else {
+                Write-Output "Resetting $($mdfcPricingTier.Name) to Free MDFC Pricing Tier for Subscription: $($subscription.name)"
+
+                Set-AzSecurityPricing -Name $mdfcPricingTier.Name -PricingTier 'Free' | Out-Null
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request updates the logic for resetting the Microsoft Defender for Cloud (MDFC) pricing tier during the landing zone destruction process. The main change is to handle the "Discovery" tier differently, ensuring it is reset to "Standard" instead of "Free," as "Standard" is the only available tier for "Discovery".

**MDFC Pricing Tier Reset Logic:**

* In `destroy-landing-zone.ps1`, added a condition to check if the MDFC pricing tier is "Discovery" and reset it to "Standard" instead of "Free", with an appropriate log message. All other tiers continue to be reset to "Free".