### PR TITLE
fix: use correct parameter for vwan hub default routetable name

### DIFF
--- a/infra-as-code/bicep/modules/vwanConnectivity/parameters/mc-vwanConnectivity.parameters.min.json
+++ b/infra-as-code/bicep/modules/vwanConnectivity/parameters/mc-vwanConnectivity.parameters.min.json
@@ -36,7 +36,7 @@
         }
       ]
     },
-    "parVhubRouteName": {
+    "parVirtualWanHubDefaultRouteName": {
       "value": "default-to-azfw"
     },
     "parVpnGatewayScaleUnit": {


### PR DESCRIPTION
... in parameterfile

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

use correct parameter for vwan hub default routetable name

## Related Issues/Work Items

Wrong parameter name was set back in #777

## This PR fixes/adds/changes/removes

use correct parameter for vwan hub default routetable name


### Breaking Changes
None

## Testing Evidence

None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
