### PR TITLE
fix: cspm plan pricing tier

### DIFF
--- a/accelerator/scripts/destroy-landing-zone.ps1
+++ b/accelerator/scripts/destroy-landing-zone.ps1
@@ -130,8 +130,13 @@ ForEach ($subscription in $subscriptionsToClean) {
         $currentMdfcForSubUnfiltered = Get-AzSecurityPricing
         $currentMdfcForSub = $currentMdfcForSubUnfiltered | Where-Object { $_.PricingTier -ne "Free" }
 
+        $standardOnlyPlans = @(
+            "Discovery",
+            "FoundationalCspm"
+        )
+
         ForEach ($mdfcPricingTier in $currentMdfcForSub) {
-            if ("Discovery" -eq $mdfcPricingTier.Name) {
+            if ($standardOnlyPlans -contains $mdfcPricingTier.Name) {
                 Write-Output "Resetting $($mdfcPricingTier.Name) to Standard MDFC Pricing Tier, as only tier available, for Subscription: $($subscription.name)"
 
                 Set-AzSecurityPricing -Name $mdfcPricingTier.Name -PricingTier 'Standard' | Out-Null


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fix issue with CSPM defender plan pricing tier in the teardown script.

## Related Issues/Work Items

N/A

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
