### PR TITLE
fix: Add missing Svc Health Alert policy param overrides for assignment

### DIFF
--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/alzDefaultPolicyAssignments.bicep
@@ -70,6 +70,20 @@ param parVmBackupExclusionTagName string = ''
 @description('Tag value for excluding VMs from this policy scope.')
 param parVmBackupExclusionTagValue array = []
 
+@description('Resource group name for the service health alert rule. Used by the Deploy-SvcHealth-BuiltIn policy assignment.')
+param parServiceHealthAlertResourceGroupName string = 'rg-serviceHealthAlert'
+
+@description('Action group resources configuration for the service health alert rule. Used by the Deploy-SvcHealth-BuiltIn policy assignment.')
+param parServiceHealthAlertActionGroupResources object = {
+  actionGroupEmail: []
+  webhookServiceUri: []
+  logicappResourceId: ''
+  logicappCallbackUrl: ''
+  eventHubResourceId: []
+  functionResourceId: ''
+  functionTriggerUrl: ''
+}
+
 @description('Names of policy assignments to exclude from the deployment entirely.')
 param parExcludedPolicyAssignments array = []
 
@@ -1011,6 +1025,17 @@ module modPolAssiIntRootDeploySvcHealthBuiltIn '../../../policy/assignments/poli
     parPolicyAssignmentDescription: varPolicyAssignmentDeploySvcHealthBuiltIn.libDefinition.properties.description
     parPolicyAssignmentNotScopes: varPolicyAssignmentDeploySvcHealthBuiltIn.libDefinition.properties.notScopes
     parPolicyAssignmentParameters: varPolicyAssignmentDeploySvcHealthBuiltIn.libDefinition.properties.parameters
+    parPolicyAssignmentParameterOverrides: {
+      resourceGroupLocation: {
+        value: parLogAnalyticsWorkSpaceAndAutomationAccountLocation
+      }
+      resourceGroupName: {
+        value: parServiceHealthAlertResourceGroupName
+      }
+      actionGroupResources: {
+        value: parServiceHealthAlertActionGroupResources
+      }
+    }
     parPolicyAssignmentIdentityType: varPolicyAssignmentDeploySvcHealthBuiltIn.libDefinition.identity.type
     parPolicyAssignmentIdentityRoleDefinitionIds: [
       varRbacRoleDefinitionIds.monitoringPolicyContributor

--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/generateddocs/alzDefaultPolicyAssignments.bicep.md
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/generateddocs/alzDefaultPolicyAssignments.bicep.md
@@ -28,6 +28,8 @@ parPolicyAssignmentsToDisableEnforcement | No       | Set the enforcement mode t
 parDisableAlzDefaultPolicies | No       | Set the enforcement mode to DoNotEnforce for all default ALZ policies.
 parVmBackupExclusionTagName | No       | Tag name for excluding VMs from this policy scope.
 parVmBackupExclusionTagValue | No       | Tag value for excluding VMs from this policy scope.
+parServiceHealthAlertResourceGroupName | No       | Resource group name for the service health alert rule. Used by the Deploy-SvcHealth-BuiltIn policy assignment.
+parServiceHealthAlertActionGroupResources | No       | Action group resources configuration for the service health alert rule. Used by the Deploy-SvcHealth-BuiltIn policy assignment.
 parExcludedPolicyAssignments | No       | Names of policy assignments to exclude from the deployment entirely.
 parTelemetryOptOut | No       | Opt out of deployment telemetry.
 parManagementGroupIdOverrides | Yes      | Specify the ALZ Default Management Group IDs to override as specified in `varManagementGroupIds`. Useful for scenarios when renaming ALZ default management groups names and IDs but not their intent or hierarchy structure.
@@ -180,6 +182,22 @@ Tag name for excluding VMs from this policy scope.
 
 Tag value for excluding VMs from this policy scope.
 
+### parServiceHealthAlertResourceGroupName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Resource group name for the service health alert rule. Used by the Deploy-SvcHealth-BuiltIn policy assignment.
+
+- Default value: `rg-serviceHealthAlert`
+
+### parServiceHealthAlertActionGroupResources
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Action group resources configuration for the service health alert rule. Used by the Deploy-SvcHealth-BuiltIn policy assignment.
+
+- Default value: `@{actionGroupEmail=System.Object[]; webhookServiceUri=System.Object[]; logicappResourceId=; logicappCallbackUrl=; eventHubResourceId=System.Object[]; functionResourceId=; functionTriggerUrl=}`
+
 ### parExcludedPolicyAssignments
 
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
@@ -277,6 +295,20 @@ Specify the ALZ Default Management Group IDs to override as specified in `varMan
         },
         "parVmBackupExclusionTagValue": {
             "value": []
+        },
+        "parServiceHealthAlertResourceGroupName": {
+            "value": "rg-serviceHealthAlert"
+        },
+        "parServiceHealthAlertActionGroupResources": {
+            "value": {
+                "actionGroupEmail": [],
+                "webhookServiceUri": [],
+                "logicappResourceId": "",
+                "logicappCallbackUrl": "",
+                "eventHubResourceId": [],
+                "functionResourceId": "",
+                "functionTriggerUrl": ""
+            }
         },
         "parExcludedPolicyAssignments": {
             "value": []

--- a/infra-as-code/bicep/modules/policy/assignments/alzDefaults/parameters/alzDefaultPolicyAssignments.parameters.all.json
+++ b/infra-as-code/bicep/modules/policy/assignments/alzDefaults/parameters/alzDefaultPolicyAssignments.parameters.all.json
@@ -71,6 +71,20 @@
     "parVmBackupExclusionTagValue": {
       "value": []
     },
+    "parServiceHealthAlertResourceGroupName": {
+      "value": "rg-serviceHealthAlert"
+    },
+    "parServiceHealthAlertActionGroupResources": {
+      "value": {
+        "actionGroupEmail": [],
+        "webhookServiceUri": [],
+        "logicappResourceId": "",
+        "logicappCallbackUrl": "",
+        "eventHubResourceId": [],
+        "functionResourceId": "",
+        "functionTriggerUrl": ""
+      }
+    },
     "parExcludedPolicyAssignments": {
       "value": []
     },

--- a/infra-as-code/bicep/modules/policy/assignments/lib/policy_assignments/policy_assignment_es_deploy_svchealth_builtin.tmpl.json
+++ b/infra-as-code/bicep/modules/policy/assignments/lib/policy_assignments/policy_assignment_es_deploy_svchealth_builtin.tmpl.json
@@ -6,7 +6,28 @@
     "description": "Assignable at the subscription or management group level, this policy ensures that each subscription has a service health alert rule configured with alert conditions and mapping to action groups as specified in the policy parameters. By default creates a resource group, alert rule and action group configured to send emails to subscription owners for all service health events.",
     "displayName": "Configure subscriptions to enable service health alert monitoring rule",
     "notScopes": [],
-    "parameters": {},
+    "parameters": {
+      "resourceGroupLocation": {
+        "value": "placeholder"
+      },
+      "resourceGroupName": {
+        "value": "rg-serviceHealthAlert"
+      },
+      "actionGroupResources": {
+        "value": {
+          "actionGroupEmail": [],
+          "webhookServiceUri": [],
+          "logicappResourceId": "",
+          "logicappCallbackUrl": "",
+          "eventHubResourceId": [],
+          "functionResourceId": "",
+          "functionTriggerUrl": ""
+        }
+      },
+      "actionGroupRoleIds": {
+        "value": ["Owner"]
+      }
+    },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/98903777-a9f6-47f5-90a9-acaf62ab01a8",
     "definitionVersion": "1.*.*-preview",
     "scope": null,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This pull request enhances the configuration and deployment of the "Deploy-SvcHealth-BuiltIn" policy assignment by introducing new parameters for service health alert resource group and action group resources. These changes provide greater flexibility and customization for service health alerting in Azure environments.

## Related Issues/Work Items

Fixes https://github.com/Azure/Azure-Landing-Zones/issues/4086

## This PR fixes/adds/changes/removes

**Service Health Alert Configuration Enhancements:**

* Added new parameters `parServiceHealthAlertResourceGroupName` and `parServiceHealthAlertActionGroupResources` to the `alzDefaultPolicyAssignments.bicep` module, allowing users to specify the resource group and action group settings for service health alert rules.
* Updated the parameters file (`alzDefaultPolicyAssignments.parameters.all.json`) to include default values for the new service health alert parameters, ensuring consistent deployment configuration.

**Policy Assignment Improvements:**

* Modified the "Deploy-SvcHealth-BuiltIn" policy assignment module to pass the new parameters (`resourceGroupName`, `actionGroupResources`, and `resourceGroupLocation`) as overrides, enabling the policy to use the specified resource group and action group configuration.
* Updated the policy assignment template (`policy_assignment_es_deploy_svchealth_builtin.tmpl.json`) to define the new parameters and provide default values, supporting the enhanced configuration options.

### Breaking Changes

None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
