### PR TITLE
fix: AzureFirewallPolicyLock collision

### DIFF
--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -610,9 +610,9 @@ resource resFirewallPolicies 'Microsoft.Network/firewallPolicies@2024-05-01' = [
 
 // Create Azure Firewall Policy resource lock if parAzFirewallEnabled is true and parGlobalResourceLock.kind != 'None' or if parAzureFirewallPolicyLock.kind != 'None'
 resource resFirewallPoliciesLock 'Microsoft.Authorization/locks@2020-05-01' = [
-  for (hub, i) in parVirtualWanHubs: if ((parVirtualHubEnabled && parVirtualWanHubs[i].parAzFirewallEnabled) && (parAzureFirewallPolicyLock.kind != 'None' || parGlobalResourceLock.kind != 'None')) {
+  for (hub, i) in parVirtualWanHubs: if ((parVirtualHubEnabled && parVirtualWanHubs[i].parAzFirewallEnabled && parAzFirewallPolicyDeploymentStyle == 'PerRegion') && (parAzureFirewallPolicyLock.kind != 'None' || parGlobalResourceLock.kind != 'None')) {
     scope: resFirewallPolicies[i]
-    name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPolicies[i].name}-lock'
+    name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPolicies[i].name}-perregion-lock'
     properties: {
       level: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.kind : parAzureFirewallPolicyLock.kind
       notes: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.?notes : parAzureFirewallPolicyLock.?notes
@@ -653,7 +653,7 @@ resource resFirewallPoliciesSharedGlobal 'Microsoft.Network/firewallPolicies@202
 // Create Azure Firewall Policy resource lock if parAzFirewallEnabled is true and parGlobalResourceLock.kind != 'None' or if parAzureFirewallPolicyLock.kind != 'None'
 resource resFirewallPoliciesLockSharedGlobal 'Microsoft.Authorization/locks@2020-05-01' = if ((parVirtualHubEnabled && parVirtualWanHubs[0].parAzFirewallEnabled && parAzFirewallPolicyDeploymentStyle == 'SharedGlobal') && (parAzureFirewallPolicyLock.kind != 'None' || parGlobalResourceLock.kind != 'None')) {
   scope: resFirewallPoliciesSharedGlobal
-  name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPoliciesSharedGlobal.name}-lock'
+  name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPoliciesSharedGlobal.name}-sharedglobal-lock'
   properties: {
     level: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.kind : parAzureFirewallPolicyLock.kind
     notes: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.?notes : parAzureFirewallPolicyLock.?notes


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

vWan Azure firewall policy lock collision issue, both when lock type set and unset.

Output errors for both setting and unsetting the lock:

Lock set to None:
     | 11:19:02 AM - Error: Code=InvalidTemplate; Message=Deployment template validation failed: 'The resource
     | 'Microsoft.Network/firewallPolicies/alz-azfwpolicy-canary-westeurope/providers/Microsoft.Authorization/locks/alz-azfwpolicy-canary-westeurope-lock' is
     | not defined in the template. Please see https://aka.ms/arm-syntax for usage details.'.

Lock set to CanNotDelete:

     | 10:56:00 AM - Error: Code=InvalidTemplate; Message=Deployment template validation failed: 'The resource
     | 'Microsoft.Network/firewallPolicies/alz-azfwpolicy-canary-westeurope/providers/Microsoft.Authorization/locks/alz-azfwpolicy-canary-westeurope-lock' at
     | line '580' and column '36' is defined multiple times in a template. Please see https://aka.ms/arm-syntax-resources for usage details.'.

## Related Issues/Work Items

- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item (internal Microsoft team member), use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## This PR fixes/adds/changes/removes

Adds parAzFirewallPolicyDeploymentStyle == 'PerRegion' to the PerRegion lock

Adds -perregion and -sharedglobal to the Azure firewall policy lock name to avoid collision

### Breaking Changes

None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
