### PR TITLE
fix(networking): firewall policy region duplication, lock collisions, and secondary-location defaults

### DIFF
--- a/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking-multiRegion.bicep.md
+++ b/infra-as-code/bicep/modules/hubNetworking/generateddocs/hubNetworking-multiRegion.bicep.md
@@ -420,7 +420,7 @@ Azure Firewall Name.
 
 Azure Firewall Name in the secondary location.
 
-- Default value: `[format('{0}-azfw-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]`
+- Default value: `[format('{0}-azfw-{1}', parameters('parCompanyPrefix'), parameters('parSecondaryLocation'))]`
 
 ### parAzFirewallPoliciesEnabled
 
@@ -452,7 +452,7 @@ Azure Firewall Policies Name.
 
 Azure Firewall Policies Name in the secondary location.
 
-- Default value: `[format('{0}-azfwpolicy-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]`
+- Default value: `[format('{0}-azfwpolicy-{1}', parameters('parCompanyPrefix'), parameters('parSecondaryLocation'))]`
 
 ### parAzFirewallPoliciesAutoLearn
 
@@ -1082,7 +1082,7 @@ outBastionNsgNameSecondaryLocation | string |
             "value": "[format('{0}-azfw-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]"
         },
         "parAzFirewallNameSecondaryLocation": {
-            "value": "[format('{0}-azfw-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]"
+            "value": "[format('{0}-azfw-{1}', parameters('parCompanyPrefix'), parameters('parSecondaryLocation'))]"
         },
         "parAzFirewallPoliciesEnabled": {
             "value": true
@@ -1094,7 +1094,7 @@ outBastionNsgNameSecondaryLocation | string |
             "value": "[format('{0}-azfwpolicy-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]"
         },
         "parAzFirewallPoliciesNameSecondaryLocation": {
-            "value": "[format('{0}-azfwpolicy-{1}', parameters('parCompanyPrefix'), parameters('parLocation'))]"
+            "value": "[format('{0}-azfwpolicy-{1}', parameters('parCompanyPrefix'), parameters('parSecondaryLocation'))]"
         },
         "parAzFirewallPoliciesAutoLearn": {
             "value": "Disabled"

--- a/infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep
+++ b/infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep
@@ -294,7 +294,7 @@ param parAzFirewallEnabledSecondaryLocation bool = true
 param parAzFirewallName string = '${parCompanyPrefix}-azfw-${parLocation}'
 
 @sys.description('Azure Firewall Name in the secondary location.')
-param parAzFirewallNameSecondaryLocation string = '${parCompanyPrefix}-azfw-${parLocation}'
+param parAzFirewallNameSecondaryLocation string = '${parCompanyPrefix}-azfw-${parSecondaryLocation}'
 
 @sys.description('Set this to true for the initial deployment as one firewall policy is required. Set this to false in subsequent deployments if using custom policies.')
 param parAzFirewallPoliciesEnabled bool = true
@@ -306,7 +306,7 @@ param parAzFirewallPoliciesEnabledSecondaryLocation bool = true
 param parAzFirewallPoliciesName string = '${parCompanyPrefix}-azfwpolicy-${parLocation}'
 
 @sys.description('Azure Firewall Policies Name in the secondary location.')
-param parAzFirewallPoliciesNameSecondaryLocation string = '${parCompanyPrefix}-azfwpolicy-${parLocation}'
+param parAzFirewallPoliciesNameSecondaryLocation string = '${parCompanyPrefix}-azfwpolicy-${parSecondaryLocation}'
 
 @description('The operation mode for automatically learning private ranges to not be SNAT.')
 param parAzFirewallPoliciesAutoLearn string = 'Disabled'
@@ -863,7 +863,7 @@ resource resVirtualNetworkLock 'Microsoft.Authorization/locks@2020-05-01' = if (
 // Create a virtual network resource lock if parGlobalResourceLock.kind != 'None' or if parVirtualNetworkLock.kind != 'None'
 resource resVirtualNetworkLockSecondaryLocation 'Microsoft.Authorization/locks@2020-05-01' = if (parVirtualNetworkLock.kind != 'None' || parGlobalResourceLock.kind != 'None') {
   scope: resHubVnetSecondaryLocation
-  name: parVirtualNetworkLock.?name ?? '${resHubVnet.name}-lock'
+  name: parVirtualNetworkLock.?name ?? '${resHubVnetSecondaryLocation.name}-lock'
   properties: {
     level: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.kind : parVirtualNetworkLock.kind
     notes: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.?notes : parVirtualNetworkLock.?notes
@@ -1809,7 +1809,7 @@ resource resFirewallPoliciesSecondaryLocation 'Microsoft.Network/firewallPolicie
 // Create Azure Firewall Policy resource lock if parAzFirewallPoliciesEnabled is true and parGlobalResourceLock.kind != 'None' or if parAzureFirewallPolicyLock.kind != 'None'
 resource resFirewallPoliciesLock 'Microsoft.Authorization/locks@2020-05-01' = if (parAzFirewallPoliciesEnabled && (parAzureFirewallPolicyLock.kind != 'None' || parGlobalResourceLock.kind != 'None')) {
   scope: resFirewallPolicies
-  name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPolicies.name}-lock'
+  name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPolicies.name}-primary-lock'
   properties: {
     level: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.kind : parAzureFirewallPolicyLock.kind
     notes: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.?notes : parAzureFirewallPolicyLock.?notes
@@ -1819,7 +1819,7 @@ resource resFirewallPoliciesLock 'Microsoft.Authorization/locks@2020-05-01' = if
 // Create Azure Firewall Policy resource lock if parAzFirewallPoliciesEnabledSecondaryLocation is true and parGlobalResourceLock.kind != 'None' or if parAzureFirewallPolicyLock.kind != 'None'
 resource resFirewallPoliciesLockSecondaryLocation 'Microsoft.Authorization/locks@2020-05-01' = if (parAzFirewallPoliciesEnabledSecondaryLocation && (parAzureFirewallPolicyLock.kind != 'None' || parGlobalResourceLock.kind != 'None')) {
   scope: resFirewallPoliciesSecondaryLocation
-  name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPoliciesSecondaryLocation.name}-lock'
+  name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPoliciesSecondaryLocation.name}-secondary-lock'
   properties: {
     level: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.kind : parAzureFirewallPolicyLock.kind
     notes: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.?notes : parAzureFirewallPolicyLock.?notes

--- a/infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md
+++ b/infra-as-code/bicep/modules/vwanConnectivity/generateddocs/vwanConnectivity.bicep.md
@@ -23,7 +23,7 @@ parVpnGatewayName | No       | VPN Gateway Name.
 parExpressRouteGatewayName | No       | ExpressRoute Gateway Name.
 parAzFirewallName | No       | Azure Firewall Name.
 parAzFirewallPolicyDeploymentStyle | No       | The deployment style of the Azure Firewall Policy. Either one shared firewall policy (`SharedGlobal`) or one policy per region (`PerRegion`), defaults to `SharedGlobal`.
-parAzFirewallPoliciesName | No       | Azure Firewall Policies Name. This is used to automatically generate a name for the Azure Firewall Policy following concat of the pattern `parAzFirewallPoliciesName-hub.parHubLocation` if you want to provide a true custom name then specify a value in each object in the array of `parVirtualWanHubs.parAzFirewallPolicyCustomName`.
+parAzFirewallPoliciesName | No       | Azure Firewall Policies Name. The hub location is appended automatically (`<name>-<hub.parHubLocation>`), unless the name already ends with `-<hub.parHubLocation>`. For a fully custom name, set `parVirtualWanHubs.parAzFirewallPolicyCustomName`.
 parAzFirewallPoliciesAutoLearn | No       | The operation mode for automatically learning private ranges to not be SNAT.
 parAzFirewallPoliciesPrivateRanges | No       | Private IP addresses/IP ranges to which traffic will not be SNAT.
 parAzureFirewallLock | No       | Resource Lock Configuration for Azure Firewall.  - `kind` - The lock settings of the service which can be CanNotDelete, ReadOnly, or None. - `notes` - Notes about this lock.  
@@ -218,7 +218,7 @@ The deployment style of the Azure Firewall Policy. Either one shared firewall po
 
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
 
-Azure Firewall Policies Name. This is used to automatically generate a name for the Azure Firewall Policy following concat of the pattern `parAzFirewallPoliciesName-hub.parHubLocation` if you want to provide a true custom name then specify a value in each object in the array of `parVirtualWanHubs.parAzFirewallPolicyCustomName`.
+Azure Firewall Policies Name. The hub location is appended automatically (`<name>-<hub.parHubLocation>`), unless the name already ends with `-<hub.parHubLocation>`. For a fully custom name, set `parVirtualWanHubs.parAzFirewallPolicyCustomName`.
 
 - Default value: `[format('{0}-azfwpolicy', parameters('parCompanyPrefix'))]`
 

--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -261,7 +261,7 @@ param parAzFirewallName string = '${parCompanyPrefix}-fw'
 @sys.description('The deployment style of the Azure Firewall Policy. Either one shared firewall policy (`SharedGlobal`) or one policy per region (`PerRegion`), defaults to `SharedGlobal`.')
 param parAzFirewallPolicyDeploymentStyle azFirewallPolicyDeploymentStyleType = 'SharedGlobal'
 
-@sys.description('Azure Firewall Policies Name. This is used to automatically generate a name for the Azure Firewall Policy following concat of the pattern `parAzFirewallPoliciesName-hub.parHubLocation` if you want to provide a true custom name then specify a value in each object in the array of `parVirtualWanHubs.parAzFirewallPolicyCustomName`.')
+@sys.description('Azure Firewall Policies Name. The hub location is appended automatically (`<name>-<hub.parHubLocation>`), unless the name already ends with `-<hub.parHubLocation>`. For a fully custom name, set `parVirtualWanHubs.parAzFirewallPolicyCustomName`.')
 param parAzFirewallPoliciesName string = '${parCompanyPrefix}-azfwpolicy'
 
 @description('The operation mode for automatically learning private ranges to not be SNAT.')
@@ -579,7 +579,7 @@ resource resErGatewayLock 'Microsoft.Authorization/locks@2020-05-01' = [
 // Create Azure Firewall Policy (per region) resources if parAzFirewallEnabled is true and parAzFirewallPolicyDeploymentStyle is set to PerRegion
 resource resFirewallPolicies 'Microsoft.Network/firewallPolicies@2024-05-01' = [
   for (hub, i) in parVirtualWanHubs: if (parVirtualHubEnabled && parVirtualWanHubs[i].parAzFirewallEnabled && parAzFirewallPolicyDeploymentStyle == 'PerRegion') {
-    name: hub.?parAzFirewallPolicyCustomName ?? '${parAzFirewallPoliciesName}-${hub.parHubLocation}'
+    name: hub.?parAzFirewallPolicyCustomName ?? (endsWith(parAzFirewallPoliciesName, '-${hub.parHubLocation}') ? parAzFirewallPoliciesName : '${parAzFirewallPoliciesName}-${hub.parHubLocation}')
     location: hub.parHubLocation
     tags: parTags
     properties: (hub.?parAzFirewallTier == 'Basic')
@@ -622,7 +622,7 @@ resource resFirewallPoliciesLock 'Microsoft.Authorization/locks@2020-05-01' = [
 
 // Shared Global Azure Firewall Policy
 resource resFirewallPoliciesSharedGlobal 'Microsoft.Network/firewallPolicies@2024-05-01' = if (parVirtualHubEnabled && parVirtualWanHubs[0].parAzFirewallEnabled && parAzFirewallPolicyDeploymentStyle == 'SharedGlobal') {
-  name: parVirtualWanHubs[0].?parAzFirewallPolicyCustomName ?? '${parAzFirewallPoliciesName}-${parVirtualWanHubs[0].parHubLocation}'
+  name: parVirtualWanHubs[0].?parAzFirewallPolicyCustomName ?? (endsWith(parAzFirewallPoliciesName, '-${parVirtualWanHubs[0].parHubLocation}') ? parAzFirewallPoliciesName : '${parAzFirewallPoliciesName}-${parVirtualWanHubs[0].parHubLocation}')
   location: parVirtualWanHubs[0].parHubLocation
   tags: parTags
   properties: (parVirtualWanHubs[0].?parAzFirewallTier == 'Basic')

--- a/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
+++ b/infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep
@@ -610,9 +610,9 @@ resource resFirewallPolicies 'Microsoft.Network/firewallPolicies@2024-05-01' = [
 
 // Create Azure Firewall Policy resource lock if parAzFirewallEnabled is true and parGlobalResourceLock.kind != 'None' or if parAzureFirewallPolicyLock.kind != 'None'
 resource resFirewallPoliciesLock 'Microsoft.Authorization/locks@2020-05-01' = [
-  for (hub, i) in parVirtualWanHubs: if ((parVirtualHubEnabled && parVirtualWanHubs[i].parAzFirewallEnabled) && (parAzureFirewallPolicyLock.kind != 'None' || parGlobalResourceLock.kind != 'None')) {
+  for (hub, i) in parVirtualWanHubs: if ((parVirtualHubEnabled && parVirtualWanHubs[i].parAzFirewallEnabled && parAzFirewallPolicyDeploymentStyle == 'PerRegion') && (parAzureFirewallPolicyLock.kind != 'None' || parGlobalResourceLock.kind != 'None')) {
     scope: resFirewallPolicies[i]
-    name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPolicies[i].name}-lock'
+    name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPolicies[i].name}-perregion-lock'
     properties: {
       level: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.kind : parAzureFirewallPolicyLock.kind
       notes: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.?notes : parAzureFirewallPolicyLock.?notes
@@ -653,7 +653,7 @@ resource resFirewallPoliciesSharedGlobal 'Microsoft.Network/firewallPolicies@202
 // Create Azure Firewall Policy resource lock if parAzFirewallEnabled is true and parGlobalResourceLock.kind != 'None' or if parAzureFirewallPolicyLock.kind != 'None'
 resource resFirewallPoliciesLockSharedGlobal 'Microsoft.Authorization/locks@2020-05-01' = if ((parVirtualHubEnabled && parVirtualWanHubs[0].parAzFirewallEnabled && parAzFirewallPolicyDeploymentStyle == 'SharedGlobal') && (parAzureFirewallPolicyLock.kind != 'None' || parGlobalResourceLock.kind != 'None')) {
   scope: resFirewallPoliciesSharedGlobal
-  name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPoliciesSharedGlobal.name}-lock'
+  name: parAzureFirewallPolicyLock.?name ?? '${resFirewallPoliciesSharedGlobal.name}-sharedglobal-lock'
   properties: {
     level: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.kind : parAzureFirewallPolicyLock.kind
     notes: (parGlobalResourceLock.kind != 'None') ? parGlobalResourceLock.?notes : parAzureFirewallPolicyLock.?notes


### PR DESCRIPTION
## Summary

Fixes a cluster of related bugs in the ALZ networking modules around firewall-policy naming and resource-lock default names. Supersedes #1159 (KiZach's lock-collision fix is included as a commit in this PR with original authorship preserved).

### Bug 1 — vWAN: region duplicated in firewall policy name

`vwanConnectivity.bicep` auto-suffixes the hub location to `parAzFirewallPoliciesName`:

```bicep
name: hub.?parAzFirewallPolicyCustomName ?? '${parAzFirewallPoliciesName}-${hub.parHubLocation}'
```

If a customer's parameters file already contains the region in `parAzFirewallPoliciesName` (e.g. `alz-azfwpolicy-eastus`), the location is appended a second time, producing names like `alz-azfwpolicy-eastus-eastus`.

**Fix:** make the name expression idempotent for both `PerRegion` and `SharedGlobal` deployment styles — only append `-${hub.parHubLocation}` when the name does not already end with it. Backward-compatible.

| `parAzFirewallPoliciesName` | hub location | Resulting name |
|---|---|---|
| `alz-azfwpolicy` | `eastus` | `alz-azfwpolicy-eastus` (unchanged) |
| `alz-azfwpolicy-eastus` | `eastus` | `alz-azfwpolicy-eastus` (was `alz-azfwpolicy-eastus-eastus`) |

### Bug 2 — vWAN: firewall policy lock collision (closes #1159)

Two problems with `resFirewallPoliciesLock` / `resFirewallPoliciesLockSharedGlobal` in `vwanConnectivity.bicep`:

1. `resFirewallPoliciesLock` is missing the `parAzFirewallPolicyDeploymentStyle == 'PerRegion'` guard, so in `SharedGlobal` mode it tries to scope to an empty array — produces `InvalidTemplate` errors.
2. `PerRegion` and `SharedGlobal` locks share the same default name suffix (`-lock`), causing collisions when both code paths are evaluated.

**Fix (cherry-picked from @KiZach #1159):**

- Add the `PerRegion` guard to `resFirewallPoliciesLock`.
- Disambiguate default lock names: `-perregion-lock` and `-sharedglobal-lock`.

### Bug 3 — `hubNetworking-multiRegion.bicep`: secondary-location defaults reference primary location

Defaults for the secondary-location firewall and firewall policy referenced `${parLocation}` instead of `${parSecondaryLocation}`:

```bicep
// before
param parAzFirewallNameSecondaryLocation         string = '${parCompanyPrefix}-azfw-${parLocation}'
param parAzFirewallPoliciesNameSecondaryLocation string = '${parCompanyPrefix}-azfwpolicy-${parLocation}'
// after
param parAzFirewallNameSecondaryLocation         string = '${parCompanyPrefix}-azfw-${parSecondaryLocation}'
param parAzFirewallPoliciesNameSecondaryLocation string = '${parCompanyPrefix}-azfwpolicy-${parSecondaryLocation}'
```

When defaults were accepted, primary and secondary firewall / firewall-policy resources resolved to the same name and collided in ARM.

### Bug 4 — `hubNetworking-multiRegion.bicep`: secondary VNet lock referenced primary VNet

`resVirtualNetworkLockSecondaryLocation` defaulted to `'${resHubVnet.name}-lock'` instead of `'${resHubVnetSecondaryLocation.name}-lock'`. With default lock names, the primary and secondary VNet locks collided.

### Bug 5 — `hubNetworking-multiRegion.bicep`: defensive lock-name disambiguation

Renamed default firewall policy lock names to `-primary-lock` / `-secondary-lock` to harden against future regressions of the kind in Bug 2.

## Files changed

- `infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep`
  - Idempotent name expression for `resFirewallPolicies` and `resFirewallPoliciesSharedGlobal`.
  - Updated parameter description for `parAzFirewallPoliciesName`.
  - Deployment-style guard on `resFirewallPoliciesLock`; `-perregion-lock` / `-sharedglobal-lock` default names.
- `infra-as-code/bicep/modules/hubNetworking/hubNetworking-multiRegion.bicep`
  - `parAzFirewallNameSecondaryLocation` and `parAzFirewallPoliciesNameSecondaryLocation` defaults now use `parSecondaryLocation`.
  - `resVirtualNetworkLockSecondaryLocation` default name now references `resHubVnetSecondaryLocation`.
  - Firewall policy lock default names disambiguated (`-primary-lock` / `-secondary-lock`).

Generated docs (`generateddocs/*.bicep.md`) are produced by the `psdocs-mdtogit` workflow on merge.

## Credits

- vWAN lock collision fix authored by @KiZach in #1159 (cherry-picked, original authorship preserved).
